### PR TITLE
Add arm/v7 platform for docker build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # docker
+
+Build images and push to Docker Hub:
+```bash
+mvn clean install -Ddockerfile.skip=false -P push-docker-amd-arm-images
+```

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
                                         <argument>build</argument>
                                         <argument>-t</argument>
                                         <argument>${docker.repo}/${docker.name}:latest</argument>
-                                        <argument>--platform=linux/amd64,linux/arm64</argument>
+                                        <argument>--platform=linux/amd64,linux/arm64,linux/arm/v7</argument>
                                         <argument>-o</argument>
                                         <argument>type=registry</argument>
                                         <argument>.</argument>
@@ -98,7 +98,7 @@
                                         <argument>build</argument>
                                         <argument>-t</argument>
                                         <argument>${docker.repo}/${docker.name}:${project.version}</argument>
-                                        <argument>--platform=linux/amd64,linux/arm64</argument>
+                                        <argument>--platform=linux/amd64,linux/arm64,linux/arm/v7</argument>
                                         <argument>-o</argument>
                                         <argument>type=registry</argument>
                                         <argument>.</argument>
@@ -119,7 +119,7 @@
                                         <argument>build</argument>
                                         <argument>-t</argument>
                                         <argument>${docker.repo}/${docker.name}:${debian.codename}</argument>
-                                        <argument>--platform=linux/amd64,linux/arm64</argument>
+                                        <argument>--platform=linux/amd64,linux/arm64,linux/arm/v7</argument>
                                         <argument>-o</argument>
                                         <argument>type=registry</argument>
                                         <argument>.</argument>
@@ -140,7 +140,7 @@
                                         <argument>build</argument>
                                         <argument>-t</argument>
                                         <argument>${docker.repo}/${docker.name}:${node.version}-${debian.codename}</argument>
-                                        <argument>--platform=linux/amd64,linux/arm64</argument>
+                                        <argument>--platform=linux/amd64,linux/arm64,linux/arm/v7</argument>
                                         <argument>-o</argument>
                                         <argument>type=registry</argument>
                                         <argument>.</argument>


### PR DESCRIPTION
Scope of changes:
* arm/v7 architecture added for base, openjdk11, openjdk8 and node images.

**arm/v7** docker arch is used in Raspberry Pi4. 
To be able to start tb images in docker on Raspberry Pi4 support for arm/v7 arch must be added. 

Successfully tested with tb-edge image on Raspberry Pi4:
https://hub.docker.com/layers/thingsboard/tb-edge-pe/3.4.3EDGEPE/images/sha256-10f1a8d290f1dcc660bf8f32535fbec4797cb2548c519511a9a49734d4d3614c?context=repo
