### PR TITLE
Fixed problems that appears while building image in multiplatform mode

### DIFF
--- a/toolbox/README.md
+++ b/toolbox/README.md
@@ -16,7 +16,6 @@ This toolbox contains a list of popular and commonly use tools/clients to help r
 * bash
 * curl
 * cqlsh
-* openjdk11
 
 ## How to use
 

--- a/toolbox/docker/Dockerfile
+++ b/toolbox/docker/Dockerfile
@@ -15,11 +15,10 @@
 #
 
 FROM alpine:${alpine.version}
-RUN apk add --no-cache postgresql-client=${psql.apk.version}
-RUN apk add --no-cache py3-pip=${pip.apk.version}
-RUN apk add --no-cache bash=${bash.apk.version}
-RUN apk add --no-cache curl=${curl.apk.version}
-RUN apk add --no-cache openjdk11=${java.apk.version}
-RUN pip install cqlsh==${cqlsh.pip.version}
+RUN apk add --no-cache postgresql-client
+RUN apk add --no-cache py3-pip
+RUN apk add --no-cache bash
+RUN apk add --no-cache curl
+RUN pip install cqlsh
 WORKDIR scripts
 COPY *.sh /scripts/

--- a/toolbox/pom.xml
+++ b/toolbox/pom.xml
@@ -34,12 +34,6 @@
         <main.dir>${basedir}/..</main.dir>
         <docker.name>toolbox</docker.name>
         <alpine.version>3.14</alpine.version>
-        <psql.apk.version>13.12-r0</psql.apk.version>
-        <pip.apk.version>20.3.4-r1</pip.apk.version>
-        <bash.apk.version>5.1.16-r0</bash.apk.version>
-        <curl.apk.version>8.0.1-r0</curl.apk.version>
-        <java.apk.version>11.0.14_p9-r0</java.apk.version>
-        <cqlsh.pip.version>6.1.2</cqlsh.pip.version>
         <docker.push-arm-amd-image.phase>pre-integration-test</docker.push-arm-amd-image.phase>
         <docker.push-arm-amd-image-debian-codename.phase>pre-integration-test</docker.push-arm-amd-image-debian-codename.phase>
     </properties>


### PR DESCRIPTION
Fixed problems that appear while building image in multiplatform mode. The root cause its that  base image does have different tools version for different platforms. For now will be added tools the latest version