### PR TITLE
1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,31 @@
 # docker
 
-Build images and push to Docker Hub:
+Build multi-arch images and push to Docker Hub:
 ```bash
-mvn clean install -Ddockerfile.skip=false -P push-docker-amd-arm-images
+mvn clean install -P push-docker-amd-arm-images
+```
+
+Build specific node version:
+```bash
+mvn clean install -P push-docker-amd-arm-images -Dnode.version=16.20.2
+```
+
+Build specific haproxy-certbot version:
+```bash
+mvn clean install -P push-docker-amd-arm-images -Dhaproxy.version=2.2.31
+```
+
+Build to your custom repo
+```bash
+mvn clean install -P push-docker-amd-arm-images -Ddocker.repo=your-docker-repo
+```
+
+Build locally with no push
+```bash
+mvn clean install -P push-docker-amd-arm-images -Ddocker.output.type=image
+```
+
+Build x64 locally (deprecated)
+```bash
+mvn clean install -Ddockerfile.skip=false -Ddockerfile.build.noCache=true
 ```

--- a/base/docker/Dockerfile
+++ b/base/docker/Dockerfile
@@ -34,4 +34,6 @@ RUN apt-get update \
             --disabled-password \
             --no-create-home \
             -gecos "Thingsboard application" \
-            ${pkg.user}
+            ${pkg.user} \
+    && rm -rf /var/log/* \
+    && chmod -R g+rwX /var/log

--- a/base/docker/Dockerfile
+++ b/base/docker/Dockerfile
@@ -18,7 +18,7 @@ FROM debian:${debian.codename}
 
 RUN apt-get update \
     && apt-get upgrade --yes \
-    && apt-get autoremove \
+    && apt-get autoremove --purge --yes \
     && apt-get install -y --no-install-recommends \
     procps \
     && apt-get clean \

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.6.0</version>
+        <version>1.7.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>base</artifactId>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -91,6 +91,18 @@
                             <tag>${project.version}</tag>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>tag-debian-codename-docker-image</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>tag</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${dockerfile.skip}</skip>
+                            <repository>${docker.repo}/${docker.name}</repository>
+                            <tag>${debian.codename}</tag>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/haproxy-certbot/docker/Dockerfile
+++ b/haproxy-certbot/docker/Dockerfile
@@ -14,51 +14,13 @@
 # limitations under the License.
 #
 
-# haproxy2.2.11 with certbot
-FROM alpine:3.16
+# haproxy with certbot
+FROM haproxy:${haproxy.version}-alpine${alpine.version}
 
-ENV HAPROXY_MAJOR 2.2
-ENV HAPROXY_VERSION 2.2.12
-
-RUN set -x \
-    \
-    &&  apk add --no-cache --virtual .build-deps \
-    ca-certificates \
-    gcc \
-    libc-dev \
-    linux-headers \
-    lua5.3-dev \
-    make \
-    openssl \
-    openssl-dev \
-    pcre2-dev \
-    readline-dev \
-    tar \
-    zlib-dev \
-    # install HAProxy
-    && wget -O haproxy.tar.gz "http://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" \
-    && mkdir -p /usr/src/haproxy \
-    && tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1  \
-    && rm haproxy.tar.gz \
-    && make -C /usr/src/haproxy -j"$(nproc)" TARGET=linux-musl CPU=generic USE_PCRE2=1 USE_PCRE2_JIT=1 USE_REGPARM=1 USE_OPENSSL=1 \
-                                USE_ZLIB=1 USE_TFO=1 USE_LINUX_TPROXY=1 USE_GETADDRINFO=1 \
-                                USE_LUA=1 LUA_LIB=/usr/lib/lua5.3 LUA_INC=/usr/include/lua5.3 \
-                                EXTRA_OBJS="contrib/prometheus-exporter/service-prometheus.o" \
-                                all  \
-    && make -C /usr/src/haproxy TARGET=linux2628 install-bin install-man  \
-    && mkdir -p /usr/local/etc/haproxy \
-    && cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \
-    && rm -rf /usr/src/haproxy  \
-    && runDeps="$( \
-    scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
-      | tr ',' '\n' \
-      | sort -u \
-      | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-  )" \
-  && apk add --virtual .haproxy-rundeps $runDeps \
-  && apk del .build-deps \
-  && apk add --no-cache openssl zlib lua5.3-libs pcre2 \
+RUN set -eux \
+  && haproxy -v \
   && apk add --no-cache --update \
+    ca-certificates \
     supervisor \
     libnl3-cli \
     net-tools \
@@ -91,5 +53,7 @@ RUN chmod +x /start.sh
 EXPOSE 80 443
 VOLUME ["/config/", "/etc/letsencrypt/", "/usr/local/etc/haproxy/certs.d/"]
 
+# Override entypoint from source image
+ENTRYPOINT []
 # Start
 CMD ["/start.sh"]

--- a/haproxy-certbot/pom.xml
+++ b/haproxy-certbot/pom.xml
@@ -38,6 +38,7 @@
         <docker.name>haproxy-certbot</docker.name>
         <docker.push-arm-amd-image.phase>pre-integration-test</docker.push-arm-amd-image.phase>
         <docker.push-arm-amd-image-latest.phase>pre-integration-test</docker.push-arm-amd-image-latest.phase>
+        <docker.push-arm-amd-image-haproxy-certbot.phase>pre-integration-test</docker.push-arm-amd-image-haproxy-certbot.phase>
     </properties>
 
     <build>

--- a/haproxy-certbot/pom.xml
+++ b/haproxy-certbot/pom.xml
@@ -21,7 +21,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.6.0</version>
+        <version>1.7.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/haproxy-certbot/pom.xml
+++ b/haproxy-certbot/pom.xml
@@ -137,6 +137,17 @@
                                     <repository>${docker.repo}/${docker.name}</repository>
                                 </configuration>
                             </execution>
+                            <execution>
+                                <id>push-haproxy-alpine-version-docker-image</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>push</goal>
+                                </goals>
+                                <configuration>
+                                    <tag>${haproxy.version}-alpine${alpine.version}</tag>
+                                    <repository>${docker.repo}/${docker.name}</repository>
+                                </configuration>
+                            </execution>
                         </executions>
                     </plugin>
                 </plugins>

--- a/node/docker/Dockerfile
+++ b/node/docker/Dockerfile
@@ -18,7 +18,7 @@ FROM node:${node.version}-${debian.codename}
 
 RUN apt-get update \
     && apt-get upgrade --yes \
-    && apt-get autoremove \
+    && apt-get autoremove --purge --yes \
     && apt-get install -y --no-install-recommends \
     procps \
     && apt-get clean \

--- a/node/pom.xml
+++ b/node/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.6.0</version>
+        <version>1.7.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>node</artifactId>

--- a/node/pom.xml
+++ b/node/pom.xml
@@ -91,6 +91,18 @@
                             <tag>${project.version}</tag>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>tag-debian-codename-docker-image</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>tag</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${dockerfile.skip}</skip>
+                            <repository>${docker.repo}/${docker.name}</repository>
+                            <tag>${debian.codename}</tag>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/openjdk11/docker/Dockerfile
+++ b/openjdk11/docker/Dockerfile
@@ -19,8 +19,8 @@ FROM thingsboard/base:${debian.codename}
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 ENV JAVA_HOME /docker-java-home
-ENV JAVA_VERSION 11.0.18
-ENV JAVA_DEBIAN_VERSION 11.0.18+10-1~deb11u1
+ENV JAVA_VERSION 11.0.20
+ENV JAVA_DEBIAN_VERSION 11.0.20+8-1~deb11u1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \

--- a/openjdk11/docker/Dockerfile
+++ b/openjdk11/docker/Dockerfile
@@ -26,7 +26,6 @@ ENV JAVA_DEBIAN_VERSION 11.0.20+8-1~deb11u1
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \
     ca-certificates \
-    && rm -rf /var/lib/apt/lists/* \
     && { \
     echo '#!/bin/sh'; \
     echo 'set -e'; \
@@ -38,10 +37,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && mkdir -p /usr/share/man/man1 \
     && set -ex; \
     \
-    apt-get update; \
+    apt list openjdk-11-jdk -a | grep openjdk-11-jdk ; \
     apt-get install -y --no-install-recommends \
     openjdk-11-jdk="$JAVA_DEBIAN_VERSION" \
     ; \
+    apt-get autoremove --purge --yes ; \
     rm -rf /var/lib/apt/lists/*; \
 # expire resolved DNS in 60 sec
     echo 'networkaddress.cache.ttl=60' >> /etc/java-11-openjdk/security/java.security \

--- a/openjdk11/docker/Dockerfile
+++ b/openjdk11/docker/Dockerfile
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+# A newer bookworm-slim is not support Java 11 by default
 FROM thingsboard/base:${debian.codename}
 
 # Default to UTF-8 file.encoding

--- a/openjdk11/docker/Dockerfile
+++ b/openjdk11/docker/Dockerfile
@@ -42,6 +42,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openjdk-11-jdk="$JAVA_DEBIAN_VERSION" \
     ; \
     rm -rf /var/lib/apt/lists/*; \
+# expire resolved DNS in 60 sec
+    echo 'networkaddress.cache.ttl=60' >> /etc/java-11-openjdk/security/java.security \
     \
 # verify that "docker-java-home" returns what we expect
     [ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ]; \

--- a/openjdk11/pom.xml
+++ b/openjdk11/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.6.0</version>
+        <version>1.7.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk11</artifactId>
@@ -33,6 +33,7 @@
     <properties>
         <main.dir>${basedir}/..</main.dir>
         <docker.name>openjdk11</docker.name>
+        <debian.codename>bullseye-slim</debian.codename> <!-- Override and freeze Debian version with the latest release that supports Java 11 -->
         <docker.push-arm-amd-image.phase>pre-integration-test</docker.push-arm-amd-image.phase>
         <docker.push-arm-amd-image-debian-codename.phase>pre-integration-test</docker.push-arm-amd-image-debian-codename.phase>
     </properties>
@@ -89,6 +90,18 @@
                             <skip>${dockerfile.skip}</skip>
                             <repository>${docker.repo}/${docker.name}</repository>
                             <tag>${project.version}</tag>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tag-debian-codename-docker-image</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>tag</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${dockerfile.skip}</skip>
+                            <repository>${docker.repo}/${docker.name}</repository>
+                            <tag>${debian.codename}</tag>
                         </configuration>
                     </execution>
                 </executions>

--- a/openjdk17/docker/Dockerfile
+++ b/openjdk17/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM thingsboard/base:${debian.codename}
+FROM ${docker.repo}/base:${debian.codename}
 
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
@@ -25,7 +25,6 @@ ENV JAVA_DEBIAN_VERSION 17.0.8+7-1~deb12u1
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \
     ca-certificates \
-    && rm -rf /var/lib/apt/lists/* \
     && { \
     echo '#!/bin/sh'; \
     echo 'set -e'; \
@@ -37,10 +36,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && mkdir -p /usr/share/man/man1 \
     && set -ex; \
     \
-    apt-get update; \
+    apt list openjdk-17-jdk -a | grep openjdk-17-jdk ; \
     apt-get install -y --no-install-recommends \
     openjdk-17-jdk="$JAVA_DEBIAN_VERSION" \
     ; \
+    apt-get autoremove --purge --yes ; \
     rm -rf /var/lib/apt/lists/*; \
 # expire resolved DNS in 60 sec
     echo 'networkaddress.cache.ttl=60' >> /etc/java-17-openjdk/security/java.security \

--- a/openjdk17/docker/Dockerfile
+++ b/openjdk17/docker/Dockerfile
@@ -42,6 +42,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openjdk-17-jdk="$JAVA_DEBIAN_VERSION" \
     ; \
     rm -rf /var/lib/apt/lists/*; \
+# expire resolved DNS in 60 sec
+    echo 'networkaddress.cache.ttl=60' >> /etc/java-17-openjdk/security/java.security \
     \
 # verify that "docker-java-home" returns what we expect
     [ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ]; \

--- a/openjdk17/docker/Dockerfile
+++ b/openjdk17/docker/Dockerfile
@@ -19,8 +19,8 @@ FROM thingsboard/base:${debian.codename}
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 ENV JAVA_HOME /docker-java-home
-ENV JAVA_VERSION 17.0.6
-ENV JAVA_DEBIAN_VERSION 17.0.6+10-1~deb11u1
+ENV JAVA_VERSION 17.0.8
+ENV JAVA_DEBIAN_VERSION 17.0.8+7-1~deb12u1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \

--- a/openjdk17/pom.xml
+++ b/openjdk17/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.6.0</version>
+        <version>1.7.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk17</artifactId>

--- a/openjdk17/pom.xml
+++ b/openjdk17/pom.xml
@@ -77,6 +77,8 @@
                             <verbose>true</verbose>
                             <googleContainerRegistryEnabled>false</googleContainerRegistryEnabled>
                             <contextDirectory>${project.build.directory}</contextDirectory>
+                            <!-- This prevents checking the latest version on docker hub to address a manifest not found issue -->
+                            <pullNewerImage>false</pullNewerImage>
                         </configuration>
                     </execution>
                     <execution>
@@ -89,6 +91,18 @@
                             <skip>${dockerfile.skip}</skip>
                             <repository>${docker.repo}/${docker.name}</repository>
                             <tag>${project.version}</tag>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tag-debian-codename-docker-image</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>tag</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${dockerfile.skip}</skip>
+                            <repository>${docker.repo}/${docker.name}</repository>
+                            <tag>${debian.codename}</tag>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <main.dir>${basedir}</main.dir>
         <pkg.user>thingsboard</pkg.user>
         <docker.repo>thingsboard</docker.repo>
+        <alpine.version>3.18</alpine.version>
         <debian.codename>bookworm-slim</debian.codename>
         <docker.output.type>registry</docker.output.type>
         <docker.cache>--no-cache</docker.cache>

--- a/pom.xml
+++ b/pom.xml
@@ -37,12 +37,14 @@
         <docker.cache>--no-cache</docker.cache>
         <docker.pull>--pull</docker.pull>
         <dockerfile.skip>true</dockerfile.skip>
+        <haproxy.version>2.2.31</haproxy.version>
         <node.version>16.20.2</node.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <docker.push-arm-amd-image.phase>none</docker.push-arm-amd-image.phase>
         <docker.push-arm-amd-image-latest.phase>none</docker.push-arm-amd-image-latest.phase>
         <docker.push-arm-amd-image-debian-codename.phase>none</docker.push-arm-amd-image-debian-codename.phase>
         <docker.push-arm-amd-image-node-version-debian-codename.phase>none</docker.push-arm-amd-image-node-version-debian-codename.phase>
+        <docker.push-arm-amd-image-haproxy-certbot.phase>none</docker.push-arm-amd-image-haproxy-certbot.phase>
     </properties>
 
     <modules>
@@ -148,6 +150,27 @@
                                         <argument>build</argument>
                                         <argument>-t</argument>
                                         <argument>${docker.repo}/${docker.name}:${node.version}-${debian.codename}</argument>
+                                        <argument>--platform=linux/amd64,linux/arm64,linux/arm/v7</argument>
+                                        <argument>-o</argument>
+                                        <argument>type=${docker.output.type}</argument>
+                                        <argument>.</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>push-debian-codename-haproxy-certbot-docker-amd-arm-images</id>
+                                <phase>${docker.push-arm-amd-image-haproxy-certbot.phase}</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>docker</executable>
+                                    <workingDirectory>${project.build.directory}</workingDirectory>
+                                    <arguments>
+                                        <argument>buildx</argument>
+                                        <argument>build</argument>
+                                        <argument>-t</argument>
+                                        <argument>${docker.repo}/${docker.name}:${haproxy.version}-alpine${alpine.version}</argument>
                                         <argument>--platform=linux/amd64,linux/arm64,linux/arm/v7</argument>
                                         <argument>-o</argument>
                                         <argument>type=${docker.output.type}</argument>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <docker.cache>--no-cache</docker.cache>
         <docker.pull>--pull</docker.pull>
         <dockerfile.skip>true</dockerfile.skip>
+        <node.version>16.20.2</node.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <docker.push-arm-amd-image.phase>none</docker.push-arm-amd-image.phase>
         <docker.push-arm-amd-image-latest.phase>none</docker.push-arm-amd-image-latest.phase>

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,11 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <main.dir>${basedir}</main.dir>
         <pkg.user>thingsboard</pkg.user>
         <docker.repo>thingsboard</docker.repo>
-        <debian.codename>bullseye-slim</debian.codename>
+        <debian.codename>bookworm-slim</debian.codename>
         <dockerfile.skip>true</dockerfile.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <docker.push-arm-amd-image.phase>none</docker.push-arm-amd-image.phase>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.thingsboard</groupId>
     <artifactId>docker</artifactId>
-    <version>1.6.0</version>
+    <version>1.7.0</version>
     <packaging>pom</packaging>
 
     <name>ThingsBoard Base Docker images</name>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,9 @@
         <pkg.user>thingsboard</pkg.user>
         <docker.repo>thingsboard</docker.repo>
         <debian.codename>bookworm-slim</debian.codename>
+        <docker.output.type>registry</docker.output.type>
+        <docker.cache>--no-cache</docker.cache>
+        <docker.pull>--pull</docker.pull>
         <dockerfile.skip>true</dockerfile.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <docker.push-arm-amd-image.phase>none</docker.push-arm-amd-image.phase>
@@ -76,11 +79,13 @@
                                     <arguments>
                                         <argument>buildx</argument>
                                         <argument>build</argument>
+                                        <argument>${docker.cache}</argument> <!-- this is important to stay up to date with apt repos -->
+                                        <argument>${docker.pull}</argument> <!-- this is important to stay up to date with docker repo -->
                                         <argument>-t</argument>
                                         <argument>${docker.repo}/${docker.name}:latest</argument>
                                         <argument>--platform=linux/amd64,linux/arm64,linux/arm/v7</argument>
                                         <argument>-o</argument>
-                                        <argument>type=registry</argument>
+                                        <argument>type=${docker.output.type}</argument>
                                         <argument>.</argument>
                                     </arguments>
                                 </configuration>
@@ -101,7 +106,7 @@
                                         <argument>${docker.repo}/${docker.name}:${project.version}</argument>
                                         <argument>--platform=linux/amd64,linux/arm64,linux/arm/v7</argument>
                                         <argument>-o</argument>
-                                        <argument>type=registry</argument>
+                                        <argument>type=${docker.output.type}</argument>
                                         <argument>.</argument>
                                     </arguments>
                                 </configuration>
@@ -122,7 +127,7 @@
                                         <argument>${docker.repo}/${docker.name}:${debian.codename}</argument>
                                         <argument>--platform=linux/amd64,linux/arm64,linux/arm/v7</argument>
                                         <argument>-o</argument>
-                                        <argument>type=registry</argument>
+                                        <argument>type=${docker.output.type}</argument>
                                         <argument>.</argument>
                                     </arguments>
                                 </configuration>
@@ -143,7 +148,7 @@
                                         <argument>${docker.repo}/${docker.name}:${node.version}-${debian.codename}</argument>
                                         <argument>--platform=linux/amd64,linux/arm64,linux/arm/v7</argument>
                                         <argument>-o</argument>
-                                        <argument>type=registry</argument>
+                                        <argument>type=${docker.output.type}</argument>
                                         <argument>.</argument>
                                     </arguments>
                                 </configuration>

--- a/toolbox/README.md
+++ b/toolbox/README.md
@@ -35,7 +35,7 @@ done
 Example of using in Kubernetes
 ```yaml
 - name: validate-db
-  image: thingsboard/toolbox:1.6.0
+  image: thingsboard/toolbox
   env: 
     # environment variable for internal scripts psql-validator and cqlsh-validator
     - name: RETRY_COUNT

--- a/toolbox/pom.xml
+++ b/toolbox/pom.xml
@@ -33,9 +33,8 @@
     <properties>
         <main.dir>${basedir}/..</main.dir>
         <docker.name>toolbox</docker.name>
-        <alpine.version>3.14</alpine.version>
         <docker.push-arm-amd-image.phase>pre-integration-test</docker.push-arm-amd-image.phase>
-        <docker.push-arm-amd-image-debian-codename.phase>pre-integration-test</docker.push-arm-amd-image-debian-codename.phase>
+        <docker.push-arm-amd-image-latest.phase>pre-integration-test</docker.push-arm-amd-image-latest.phase>
     </properties>
 
     <build>

--- a/toolbox/pom.xml
+++ b/toolbox/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.thingsboard</groupId>
         <artifactId>docker</artifactId>
-        <version>1.6.0</version>
+        <version>1.7.0</version>
     </parent>
 
     <artifactId>toolbox</artifactId>

--- a/website/docker/Dockerfile
+++ b/website/docker/Dockerfile
@@ -18,7 +18,7 @@ FROM ruby:2.7.7
 
 RUN apt-get update \
     && apt-get upgrade --yes \
-    && apt-get autoremove \
+    && apt-get autoremove --purge --yes \
     && apt-get install -y --no-install-recommends \
         software-properties-common make g++ graphicsmagick-imagemagick-compat\
     && apt-get clean \

--- a/website/pom.xml
+++ b/website/pom.xml
@@ -34,7 +34,7 @@
         <main.dir>${basedir}/..</main.dir>
         <docker.name>website</docker.name>
         <docker.push-arm-amd-image.phase>pre-integration-test</docker.push-arm-amd-image.phase>
-        <docker.push-arm-amd-image-debian-codename.phase>pre-integration-test</docker.push-arm-amd-image-debian-codename.phase>
+        <docker.push-arm-amd-image-latest.phase>pre-integration-test</docker.push-arm-amd-image-latest.phase>
     </properties>
 
     <build>

--- a/website/pom.xml
+++ b/website/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.6.0</version>
+        <version>1.7.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>website</artifactId>


### PR DESCRIPTION
## Version Updates
* bump **Debian 12**
* bump **Alpine 3.18**
* bump **Java 11** minor version (frozen on Debian 11)
* bump **Java 17** minor version
* bump **Node 16** minor version
* bump **haproxy** minor version 2.2.31 (from 2.2.12)
* **haproxy** build from sources replaced with official **FROM haproxy:2.2.31-alpine3.18**. build [command](https://hub.docker.com/layers/library/haproxy/2.2.31-alpine3.18/images/sha256-bb9fd5346c114f425a1b478abd82f971cdffa2559e6e2e359ca57296537fedbf?context=explore) compared before refactoring.
* bump exec-maven-plugin 3.1.0
* Make logs folder writeable to avoid log volume mount: `chmod -R g+rwX /var/log`
* **Expire resolved DNS in 60 sec** for Java 11 and Java 17
* Old fashion docker build updated for local builds (x64 only)
* Docker build with `--no-cache` and `--pull` to stay up to date
* Docker image minor optimizations
* Docker parameters were added to gain more control of the build.
* Readme updated.
* Docker **repo version** **1.7.0**

Please take a look at the commit log for details.

Note: haproxy 2.22 end of life 2025 Q2
![image](https://github.com/thingsboard/docker/assets/79898499/d1bbbcf8-9e89-4ab6-b5cb-75a7cd5aa1fd)

Build runs OK
![image](https://github.com/thingsboard/docker/assets/79898499/b26ccaa4-2e3e-46b4-8ce3-d390e7fc885c)

Push results to the private repo
![image](https://github.com/thingsboard/docker/assets/79898499/30e46e64-1810-48c7-87cb-a6a613f2ade1)
![image](https://github.com/thingsboard/docker/assets/79898499/18297588-8fc3-4abb-80d4-1c55d31b51d0)
![image](https://github.com/thingsboard/docker/assets/79898499/db489ac5-b5a1-4f18-836c-b439e0ff07a7)
![image](https://github.com/thingsboard/docker/assets/79898499/3aeca2fd-2aa0-46b4-bb35-51d8c4932d90)
![image](https://github.com/thingsboard/docker/assets/79898499/936191a6-56de-48f0-97c6-ed3402c865bc)
![image](https://github.com/thingsboard/docker/assets/79898499/0638e76c-7f46-4f31-807f-f8d5447c48cb)
![image](https://github.com/thingsboard/docker/assets/79898499/85c93526-fc85-4be4-954b-9180577eb227)

