### PR TITLE
haproxy.version=2.2.33 , removed tc qdisc to be able to run container under macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ mvn clean install -P push-docker-amd-arm-images -Dnode.version=16.20.2
 
 Build specific haproxy-certbot version:
 ```bash
-mvn clean install -P push-docker-amd-arm-images -Dhaproxy.version=2.2.31
+mvn clean install -P push-docker-amd-arm-images -Dhaproxy.version=2.2.33
 ```
 
 Build to your custom repo

--- a/haproxy-certbot/docker/Dockerfile
+++ b/haproxy-certbot/docker/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # haproxy with certbot
-FROM haproxy:${haproxy.version}-alpine${alpine.version}
+FROM haproxy:${haproxy.version}-alpine
 
 RUN set -eux \
   && haproxy -v \

--- a/haproxy-certbot/docker/haproxy-restart.sh
+++ b/haproxy-certbot/docker/haproxy-restart.sh
@@ -15,7 +15,4 @@
 # limitations under the License.
 #
 
-
-nl-qdisc-add --dev=lo --parent=1:4 --id=40: --update plug --buffer
 /usr/local/sbin/haproxy -f /config/haproxy.cfg -D -p /var/run/haproxy.pid -sf $(cat /var/run/haproxy.pid)
-nl-qdisc-add --dev=lo --parent=1:4 --id=40: --update plug --release-indefinite

--- a/haproxy-certbot/docker/start.sh
+++ b/haproxy-certbot/docker/start.sh
@@ -47,24 +47,5 @@ if [ ! -e ${DEFAULT_PEM} ]; then
   echo ${PASSWORD} > /password.txt
 fi
 
-# Mark Syn Packets
-IP=$(echo `ifconfig eth0 2>/dev/null|awk '/inet addr:/ {print $2}'|sed 's/addr://'`)
-/sbin/iptables -t mangle -I OUTPUT -p tcp -s ${IP} --syn -j MARK --set-mark 1
-
-# Set up the queuing discipline
-tc qdisc add dev lo root handle 1: prio bands 4
-tc qdisc add dev lo parent 1:1 handle 10: pfifo limit 1000
-tc qdisc add dev lo parent 1:2 handle 20: pfifo limit 1000
-tc qdisc add dev lo parent 1:3 handle 30: pfifo limit 1000
-
-# Create a plug qdisc with 32 meg of buffer
-nl-qdisc-add --dev=lo --parent=1:4 --id=40: plug --limit 33554432
-# Release the plug
-nl-qdisc-add --dev=lo --parent=1:4 --id=40: --update plug --release-indefinite
-
-# Set up the filter, any packet marked with "1" will be
-# directed to the plug
-tc filter add dev lo protocol ip parent 1:0 prio 1 handle 1 fw classid 1:4
-
 # Run Supervisor
 exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/haproxy-certbot/pom.xml
+++ b/haproxy-certbot/pom.xml
@@ -144,7 +144,7 @@
                                     <goal>push</goal>
                                 </goals>
                                 <configuration>
-                                    <tag>${haproxy.version}-alpine${alpine.version}</tag>
+                                    <tag>${haproxy.version}-alpine</tag>
                                     <repository>${docker.repo}/${docker.name}</repository>
                                 </configuration>
                             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <docker.cache>--no-cache</docker.cache>
         <docker.pull>--pull</docker.pull>
         <dockerfile.skip>true</dockerfile.skip>
-        <haproxy.version>2.2.31</haproxy.version>
+        <haproxy.version>2.2.33</haproxy.version>
         <node.version>16.20.2</node.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <docker.push-arm-amd-image.phase>none</docker.push-arm-amd-image.phase>


### PR DESCRIPTION
# haproxy.version=2.2.33 , removed tc qdisc to be able to run container under macos

1. Bump to the latest LTS 2.2.33
2. Removed linux-specific traffic control because `qdisc` is not available on macos (apple silicon, M1 - M3). The source `haproxy` image does not use external traffic control utils as well 

Issue: https://github.com/thingsboard/thingsboard/issues/1550

It will open the ability to run the black-box-tests on mac