### PR TITLE
haproxy-certbot tag alpine without alpine version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
                                         <argument>buildx</argument>
                                         <argument>build</argument>
                                         <argument>-t</argument>
-                                        <argument>${docker.repo}/${docker.name}:${haproxy.version}-alpine${alpine.version}</argument>
+                                        <argument>${docker.repo}/${docker.name}:${haproxy.version}-alpine</argument>
                                         <argument>--platform=linux/amd64,linux/arm64,linux/arm/v7</argument>
                                         <argument>-o</argument>
                                         <argument>type=${docker.output.type}</argument>


### PR DESCRIPTION
# haproxy-certbot tag alpine without alpine version

Previously, it was said 3.18, but they rolled back to 3.16 in the upstream image.
Now, we are using a rolling tag -apline to avoid misleading.

![image](https://github.com/thingsboard/docker/assets/79898499/a23ab6b8-ce2b-4f1c-b0ed-9e1a47aef3e6)
