### PR TITLE
website:1.9.0 from ruby 2.7.7 and elder gems that does not require ruby > 3.0.0

### DIFF
--- a/website/docker/Dockerfile
+++ b/website/docker/Dockerfile
@@ -23,7 +23,12 @@ RUN apt-get update \
         software-properties-common make g++ graphicsmagick-imagemagick-compat\
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && gem install 'github-pages' 'jekyll:~>3.9.2'
+    && gem install bundler -v 2.0.1 \
+    && gem install 'jekyll:~>3.9.2' \
+    && gem install nokogiri -v 1.15.5 \
+    && gem install faraday-net_http -v 3.0.2 \
+    && gem install faraday -v 2.8.1 \
+    && gem install 'github-pages'
 
 WORKDIR /website/
 


### PR DESCRIPTION
# website:1.9.0 from ruby 2.7.7 and elder gems that does not require ruby > 3.0.0

This fixes the issues with the build
```
#11 329.5 ERROR:  Error installing github-pages:
#11 329.5       The last version of nokogiri (>= 1.13.6, < 2.0) to support your Ruby & RubyGems was 1.15.6. Try installing it with `gem install nokogiri -v 1.15.6` and then running the current command again
#11 329.5       nokogiri requires Ruby version >= 3.0, < 3.4.dev. The current ruby version is 2.7.7.221.

```

![image](https://github.com/thingsboard/docker/assets/79898499/b513ffc4-15f6-4996-bf09-b44c698fe6c4)
