### PR TITLE
Java minor update, base image home dir created

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,17 @@ Build multi-arch images and push to Docker Hub:
 docker buildx prune
 mvn clean install -P push-docker-amd-arm-images -pl base -Ddebian.codename=bullseye-slim
 mvn clean install -P push-docker-amd-arm-images -pl base
-mvn clean install -P push-docker-amd-arm-images -pl '!base,!openjdk21'
+mvn clean install -P push-docker-amd-arm-images -pl '!base'
 ```
 
 Build specific node version:
 ```bash
 mvn clean install -P push-docker-amd-arm-images -Dnode.version=16.20.2
+``` 
+
+Build only specific node version on specific Debian codename
+```bash
+mvn clean install -P push-docker-amd-arm-images --projects=node -Dnode.version=16.20.2 -Ddebian.codename=bullseye-slim -Ddocker.push-arm-amd-image.phase=none -Ddocker.push-arm-amd-image-latest.phase=none
 ```
 
 Build specific haproxy-certbot version:
@@ -28,7 +33,20 @@ Build locally with no push
 mvn clean install -P push-docker-amd-arm-images -Ddocker.output.type=image
 ```
 
+Build locally with --load
+```bash
+mvn clean install -P push-docker-amd-arm-images -Ddocker.output.type=image --projects="openjdk21" -am
+```
+
 Build x64 locally (deprecated)
 ```bash
 mvn clean install -Ddockerfile.skip=false -Ddockerfile.build.noCache=true
+```
+
+### Multi-arch build setup
+If you failed to build or see some segmentation fault during the build, check your qemu and builder setup
+
+```bash
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker run --rm -t arm64v8/ubuntu uname -m
 ```

--- a/base/docker/Dockerfile
+++ b/base/docker/Dockerfile
@@ -15,12 +15,12 @@
 #
 
 FROM debian:${debian.codename}
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
     && apt-get upgrade --yes \
+    && apt-get install -y --no-install-recommends procps \
     && apt-get autoremove --purge --yes \
-    && apt-get install -y --no-install-recommends \
-    procps \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && addgroup --system ${pkg.user} \
@@ -32,8 +32,13 @@ RUN apt-get update \
             --quiet \
             --disabled-login \
             --disabled-password \
-            --no-create-home \
             -gecos "Thingsboard application" \
             ${pkg.user} \
     && rm -rf /var/log/* \
-    && chmod -R g+rwX /var/log
+    && chmod -R g+rwX /var/log \
+    && mkdir -p /home/${pkg.user} \
+    && chown ${pkg.user}:${pkg.user} /home/${pkg.user} \
+    && chmod -R g+rwX /home/${pkg.user} \
+    && ls -lah /home/${pkg.user}
+
+ENV HOME=/home/${pkg.user}

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.9.0</version>
+        <version>1.10.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>base</artifactId>

--- a/haproxy-certbot/pom.xml
+++ b/haproxy-certbot/pom.xml
@@ -21,7 +21,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.9.0</version>
+        <version>1.10.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/node/pom.xml
+++ b/node/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.9.0</version>
+        <version>1.10.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>node</artifactId>

--- a/openjdk11/docker/Dockerfile
+++ b/openjdk11/docker/Dockerfile
@@ -20,8 +20,8 @@ FROM thingsboard/base:${debian.codename}
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 ENV JAVA_HOME /docker-java-home
-ENV JAVA_VERSION 11.0.23
-ENV JAVA_DEBIAN_VERSION 11.0.23+9-1~deb11u1
+ENV JAVA_VERSION 11.0.24
+ENV JAVA_DEBIAN_VERSION 11.0.24+8-2~deb11u1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \
@@ -35,21 +35,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && chmod +x /usr/local/bin/docker-java-home \
     && ln -svT "/usr/lib/jvm/java-11-openjdk-$(dpkg --print-architecture)" /docker-java-home \
     && mkdir -p /usr/share/man/man1 \
-    && set -ex; \
-    \
-    apt list openjdk-11-jdk -a | grep openjdk-11-jdk ; \
-    apt-get install -y --no-install-recommends \
+    && set -ex \
+    && apt list openjdk-11-jdk -a | grep openjdk-11-jdk \
+    && apt-get install -y --no-install-recommends \
     openjdk-11-jdk="$JAVA_DEBIAN_VERSION" \
-    ; \
-    apt-get autoremove --purge --yes ; \
-    rm -rf /var/lib/apt/lists/*; \
+    && apt-get autoremove --purge --yes \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
 # expire resolved DNS in 60 sec
-    echo 'networkaddress.cache.ttl=60' >> /etc/java-11-openjdk/security/java.security ; \
-    \
+    && echo 'networkaddress.cache.ttl=60' >> /etc/java-11-openjdk/security/java.security \
+    && tail /etc/java-11-openjdk/security/java.security \
 # verify that "docker-java-home" returns what we expect
-    [ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ]; \
-    \
+    && [ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ] \
 # basic smoke test
-    fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
-	javac -version; \
-	java -version
+    && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ] \
+    && rm -rf ~/.java \
+	&& javac -version \
+	&& java -version

--- a/openjdk11/pom.xml
+++ b/openjdk11/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.9.0</version>
+        <version>1.10.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk11</artifactId>

--- a/openjdk17/docker/Dockerfile
+++ b/openjdk17/docker/Dockerfile
@@ -19,8 +19,8 @@ FROM ${docker.repo}/base:${debian.codename}
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 ENV JAVA_HOME /docker-java-home
-ENV JAVA_VERSION 17.0.11
-ENV JAVA_DEBIAN_VERSION 17.0.11+9-1~deb12u1
+ENV JAVA_VERSION 17.0.12
+ENV JAVA_DEBIAN_VERSION 17.0.12+7-2~deb12u1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \
@@ -34,21 +34,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && chmod +x /usr/local/bin/docker-java-home \
     && ln -svT "/usr/lib/jvm/java-17-openjdk-$(dpkg --print-architecture)" /docker-java-home \
     && mkdir -p /usr/share/man/man1 \
-    && set -ex; \
-    \
-    apt list openjdk-17-jdk -a | grep openjdk-17-jdk ; \
-    apt-get install -y --no-install-recommends \
+    && set -ex \
+    && apt list openjdk-17-jdk -a | grep openjdk-17-jdk \
+    && apt-get install -y --no-install-recommends \
     openjdk-17-jdk="$JAVA_DEBIAN_VERSION" \
-    ; \
-    apt-get autoremove --purge --yes ; \
-    rm -rf /var/lib/apt/lists/*; \
+    && apt-get autoremove --purge --yes \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
 # expire resolved DNS in 60 sec
-    echo 'networkaddress.cache.ttl=60' >> /etc/java-17-openjdk/security/java.security ; \
-    \
+    && echo 'networkaddress.cache.ttl=60' >> /etc/java-17-openjdk/security/java.security \
+    && tail /etc/java-17-openjdk/security/java.security \
 # verify that "docker-java-home" returns what we expect
-    [ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ]; \
-    \
+    && [ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ] \
+    && pwd \
+    && ls -lah ~ \
 # basic smoke test
-    fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
-	javac -version; \
-	java -version
+    && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ] \
+    && rm -rf ~/.java \
+	&& javac -version \
+	&& java -version

--- a/openjdk17/pom.xml
+++ b/openjdk17/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.9.0</version>
+        <version>1.10.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk17</artifactId>

--- a/openjdk21/docker/Dockerfile
+++ b/openjdk21/docker/Dockerfile
@@ -19,8 +19,8 @@ FROM ${docker.repo}/base:${debian.codename}
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 ENV JAVA_HOME /docker-java-home
-ENV JAVA_VERSION 21.0.2
-ENV JAVA_DEBIAN_VERSION 21.0.2+13-2
+ENV JAVA_VERSION 21.0.5
+ENV JAVA_DEBIAN_VERSION 21.0.5~8ea-1
 
 # Remove when stable version is available
 RUN echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.d/trixie.list
@@ -37,21 +37,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && chmod +x /usr/local/bin/docker-java-home \
     && ln -svT "/usr/lib/jvm/java-21-openjdk-$(dpkg --print-architecture)" /docker-java-home \
     && mkdir -p /usr/share/man/man1 \
-    && set -ex; \
-    \
-    apt list openjdk-21-jdk -a | grep openjdk-21-jdk ; \
-    apt-get install -y --no-install-recommends \
+    && set -ex \
+    && apt list openjdk-21-jdk -a | grep openjdk-21-jdk \
+    && apt-get install -y --no-install-recommends \
     openjdk-21-jdk="$JAVA_DEBIAN_VERSION" \
-    ; \
-    apt-get autoremove --purge --yes ; \
-    rm -rf /var/lib/apt/lists/*; \
+    && apt-get autoremove --purge --yes \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
 # expire resolved DNS in 60 sec
-    echo 'networkaddress.cache.ttl=60' >> /etc/java-21-openjdk/security/java.security ; \
-    \
+    && echo 'networkaddress.cache.ttl=60' >> /etc/java-21-openjdk/security/java.security \
+    && tail /etc/java-21-openjdk/security/java.security \
 # verify that "docker-java-home" returns what we expect
-    [ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ]; \
-    \
+    && [ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ] \
+    && pwd \
+    && ls -lah ~ \
 # basic smoke test
-    fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
-	javac -version; \
-	java -version
+    && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ] \
+    && rm -rf ~/.java \
+	&& javac -version \
+	&& java -version

--- a/openjdk21/pom.xml
+++ b/openjdk21/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.7.0</version>
+        <version>1.10.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk21</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.thingsboard</groupId>
     <artifactId>docker</artifactId>
-    <version>1.9.0</version>
+    <version>1.10.0</version>
     <packaging>pom</packaging>
 
     <name>ThingsBoard Base Docker images</name>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <docker.pull>--pull</docker.pull>
         <dockerfile.skip>true</dockerfile.skip>
         <haproxy.version>2.2.33</haproxy.version>
-        <node.version>16.20.2</node.version>
+        <node.version>18.20.4</node.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <docker.push-arm-amd-image.phase>none</docker.push-arm-amd-image.phase>
         <docker.push-arm-amd-image-latest.phase>none</docker.push-arm-amd-image-latest.phase>

--- a/toolbox/pom.xml
+++ b/toolbox/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.thingsboard</groupId>
         <artifactId>docker</artifactId>
-        <version>1.9.0</version>
+        <version>1.10.0</version>
     </parent>
 
     <artifactId>toolbox</artifactId>

--- a/website/pom.xml
+++ b/website/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.9.0</version>
+        <version>1.10.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>website</artifactId>


### PR DESCRIPTION
Java minor update, base image home dir created
v. 1.10.0

Tests: 
tested on a custom repo 
tested on QA upgrade with SVG conversion
tested QA full build
tested QA deployment with based on new images

UPD **node.js** ([EOL 16](https://nodejs.org/en/about/previous-releases))
![image](https://github.com/user-attachments/assets/0d28c428-168b-43c3-b0d6-82264a88d724)
