### PR TITLE
Node JS 20.18.0 , Java security update, build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Build multi-arch images and push to Docker Hub:
 ```bash
-docker buildx prune
+# do not ask user for interactive confirmation
+docker buildx prune -f
 mvn clean install -P push-docker-amd-arm-images -pl base -Ddebian.codename=bullseye-slim
 mvn clean install -P push-docker-amd-arm-images -pl base
 mvn clean install -P push-docker-amd-arm-images -pl '!base'

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.10.0</version>
+        <version>1.11.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>base</artifactId>

--- a/build_and_push_all.sh
+++ b/build_and_push_all.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+# Copyright © 2016-2020 The Thingsboard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e # exit on any error
+
+# Fetch the current branch name and latest commit ID
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD | sed 's/[\/]/-/g')
+COMMIT_ID=$(git rev-parse --short HEAD)
+
+# Combine them to create a version tag
+VERSION_TAG="${BRANCH_NAME}-${COMMIT_ID}"
+
+echo "$(date) Building project from $VERSION_TAG ..."
+set -x
+
+# Performing the same steps as described in README.md
+docker buildx prune -f
+mvn clean install -P push-docker-amd-arm-images -pl base -Ddebian.codename=bullseye-slim
+mvn clean install -P push-docker-amd-arm-images -pl base
+mvn clean install -P push-docker-amd-arm-images -pl '!base'
+
+set +x
+echo "$(date) Done. ${VERSION_TAG}"

--- a/haproxy-certbot/pom.xml
+++ b/haproxy-certbot/pom.xml
@@ -21,7 +21,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.10.0</version>
+        <version>1.11.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/node/pom.xml
+++ b/node/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.10.0</version>
+        <version>1.11.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>node</artifactId>

--- a/openjdk11/docker/Dockerfile
+++ b/openjdk11/docker/Dockerfile
@@ -20,8 +20,8 @@ FROM thingsboard/base:${debian.codename}
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 ENV JAVA_HOME /docker-java-home
-ENV JAVA_VERSION 11.0.24
-ENV JAVA_DEBIAN_VERSION 11.0.24+8-2~deb11u1
+ENV JAVA_VERSION 11.0.25
+ENV JAVA_DEBIAN_VERSION 11.0.25+9-1~deb11u1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \

--- a/openjdk11/pom.xml
+++ b/openjdk11/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.10.0</version>
+        <version>1.11.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk11</artifactId>

--- a/openjdk17/docker/Dockerfile
+++ b/openjdk17/docker/Dockerfile
@@ -19,8 +19,8 @@ FROM ${docker.repo}/base:${debian.codename}
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 ENV JAVA_HOME /docker-java-home
-ENV JAVA_VERSION 17.0.12
-ENV JAVA_DEBIAN_VERSION 17.0.12+7-2~deb12u1
+ENV JAVA_VERSION 17.0.13
+ENV JAVA_DEBIAN_VERSION 17.0.13+11-2~deb12u1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \

--- a/openjdk17/pom.xml
+++ b/openjdk17/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.10.0</version>
+        <version>1.11.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk17</artifactId>

--- a/openjdk21/docker/Dockerfile
+++ b/openjdk21/docker/Dockerfile
@@ -20,7 +20,7 @@ FROM ${docker.repo}/base:${debian.codename}
 ENV LANG C.UTF-8
 ENV JAVA_HOME /docker-java-home
 ENV JAVA_VERSION 21.0.5
-ENV JAVA_DEBIAN_VERSION 21.0.5~8ea-1
+ENV JAVA_DEBIAN_VERSION 21.0.5+11-1
 
 # Remove when stable version is available
 RUN echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.d/trixie.list

--- a/openjdk21/pom.xml
+++ b/openjdk21/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.10.0</version>
+        <version>1.11.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk21</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.thingsboard</groupId>
     <artifactId>docker</artifactId>
-    <version>1.10.0</version>
+    <version>1.11.0</version>
     <packaging>pom</packaging>
 
     <name>ThingsBoard Base Docker images</name>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <docker.pull>--pull</docker.pull>
         <dockerfile.skip>true</dockerfile.skip>
         <haproxy.version>2.2.33</haproxy.version>
-        <node.version>18.20.4</node.version>
+        <node.version>20.18.0</node.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <docker.push-arm-amd-image.phase>none</docker.push-arm-amd-image.phase>
         <docker.push-arm-amd-image-latest.phase>none</docker.push-arm-amd-image-latest.phase>

--- a/toolbox/pom.xml
+++ b/toolbox/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.thingsboard</groupId>
         <artifactId>docker</artifactId>
-        <version>1.10.0</version>
+        <version>1.11.0</version>
     </parent>
 
     <artifactId>toolbox</artifactId>

--- a/website/pom.xml
+++ b/website/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.10.0</version>
+        <version>1.11.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>website</artifactId>


### PR DESCRIPTION
- Java security updates
- Node JS 20.18.0 regarding the https://github.com/thingsboard/thingsboard/pull/11767
- build script added

to build run `./build_and_push_all.sh`