### PR TITLE
fixed env name typo in README.md to match the env variable name

### DIFF
--- a/toolbox/README.md
+++ b/toolbox/README.md
@@ -49,7 +49,7 @@ Example of using in Kubernetes
       value: "POSTGRES DATABASE"
     - name: PGUSER
       value: "POSTGRES USER"
-    - name: QUERY_TO_VALIDATE
+    - name: QUERY_TO_VALIDATE_DATA
       value: "Select SOMETHING"
     - name: PGPASSWORD
       valueFrom:


### PR DESCRIPTION
Based on psql-validator.sh the variable name should be `QUERY_TO_VALIDATE_DATA`:

![image](https://github.com/user-attachments/assets/d5d5fdc5-f7c3-49e4-8514-7c9c4f2dc8e7)
