### PR TITLE
Fix for missing user homedir, bump versions, fix website builds

### DIFF
--- a/base/docker/Dockerfile
+++ b/base/docker/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update \
     && mkdir -p /home/${pkg.user} \
     && chown ${pkg.user}:${pkg.user} /home/${pkg.user} \
     && chmod -R g+rwX /home/${pkg.user} \
+    && usermod -d /home/${pkg.user} ${pkg.user} \
     && ls -lah /home/${pkg.user}
 
 ENV HOME=/home/${pkg.user}

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.13.0</version>
+        <version>1.14.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>base</artifactId>

--- a/haproxy-certbot/pom.xml
+++ b/haproxy-certbot/pom.xml
@@ -21,7 +21,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.13.0</version>
+        <version>1.14.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/kubectl/pom.xml
+++ b/kubectl/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.13.0</version>
+        <version>1.14.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>kubectl</artifactId>

--- a/medusa/pom.xml
+++ b/medusa/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.13.0</version>
+        <version>1.14.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>medusa</artifactId>

--- a/node/pom.xml
+++ b/node/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.13.0</version>
+        <version>1.14.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>node</artifactId>

--- a/openjdk11/docker/Dockerfile
+++ b/openjdk11/docker/Dockerfile
@@ -20,8 +20,8 @@ FROM thingsboard/base:${debian.codename}
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 ENV JAVA_HOME /docker-java-home
-ENV JAVA_VERSION 11.0.25
-ENV JAVA_DEBIAN_VERSION 11.0.25+9-1~deb11u1
+ENV JAVA_VERSION 11.0.26
+ENV JAVA_DEBIAN_VERSION 11.0.26+4-1~deb11u1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \

--- a/openjdk11/pom.xml
+++ b/openjdk11/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.13.0</version>
+        <version>1.14.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk11</artifactId>

--- a/openjdk17/docker/Dockerfile
+++ b/openjdk17/docker/Dockerfile
@@ -19,8 +19,8 @@ FROM ${docker.repo}/base:${debian.codename}
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 ENV JAVA_HOME /docker-java-home
-ENV JAVA_VERSION 17.0.13
-ENV JAVA_DEBIAN_VERSION 17.0.13+11-2~deb12u1
+ENV JAVA_VERSION 17.0.14
+ENV JAVA_DEBIAN_VERSION 17.0.14+7-1~deb12u1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \

--- a/openjdk17/pom.xml
+++ b/openjdk17/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.13.0</version>
+        <version>1.14.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk17</artifactId>

--- a/openjdk21/docker/Dockerfile
+++ b/openjdk21/docker/Dockerfile
@@ -19,8 +19,8 @@ FROM ${docker.repo}/base:${debian.codename}
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 ENV JAVA_HOME /docker-java-home
-ENV JAVA_VERSION 21.0.5
-ENV JAVA_DEBIAN_VERSION 21.0.5+11-1
+ENV JAVA_VERSION 21.0.6
+ENV JAVA_DEBIAN_VERSION 21.0.6+7-1
 
 # Remove when stable version is available
 RUN echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.d/trixie.list

--- a/openjdk21/pom.xml
+++ b/openjdk21/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.13.0</version>
+        <version>1.14.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk21</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.thingsboard</groupId>
     <artifactId>docker</artifactId>
-    <version>1.13.0</version>
+    <version>1.14.0</version>
     <packaging>pom</packaging>
 
     <name>ThingsBoard Base Docker images</name>

--- a/toolbox/pom.xml
+++ b/toolbox/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.thingsboard</groupId>
         <artifactId>docker</artifactId>
-        <version>1.13.0</version>
+        <version>1.14.0</version>
     </parent>
 
     <artifactId>toolbox</artifactId>

--- a/website/docker/Dockerfile
+++ b/website/docker/Dockerfile
@@ -15,8 +15,10 @@
 #
 
 FROM ruby:3.2.2
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN    apt-get update \
+    && apt-get upgrade --yes \
     && apt-get install -y --no-install-recommends \
         software-properties-common make g++ graphicsmagick-imagemagick-compat \
     && apt-get autoremove --purge --yes \

--- a/website/pom.xml
+++ b/website/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.13.0</version>
+        <version>1.14.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>website</artifactId>


### PR DESCRIPTION
## Pull Request description

When `thingsboard` user is added as a part of service installation (`thingsboard.deb`) on any Docker image, home directory is not properly configured and set as placeholder `/nonexistent`. This produces some warnings (e.g. JGit config dir creation), and in - some cases - critical startup errors (e.g. RocksDB init).
Examples:
<details>
  <summary>JGit</summary>
   <pre>
2025-03-10 14:18:04,041 [JGit-FileStoreAttributeWriter-2] ERROR org.eclipse.jgit.util.FS - Cannot save config file 'FileBasedConfig[/nonexistent/.config/jgit/config]'
java.io.IOException: Creating directories for /nonexistent/.config/jgit failed
 at org.eclipse.jgit.util.FileUtils.mkdirs(FileUtils.java:421)
 at org.eclipse.jgit.internal.storage.file.LockFile.lock(LockFile.java:144)
 at org.eclipse.jgit.storage.file.FileBasedConfig.save(FileBasedConfig.java:201)
 at org.eclipse.jgit.util.FS$FileStoreAttributes.saveToConfig(FS.java:776)
 at org.eclipse.jgit.util.FS$FileStoreAttributes.lambda$5(FS.java:458)
 at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
 at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
 at java.base/java.lang.Thread.run(Thread.java:840)
   </pre>
</details>
<details>
  <summary>RocksDB</summary>
   <pre>
Error starting ApplicationContext. To display the condition evaluation report re-run your application with 'debug' enabled.
2025-03-10 12:30:37,712 [main] ERROR o.s.boot.SpringApplication - Application run failed
org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'defaultTbCalculatedFieldConsumerService' defined in URL [jar:nested:/usr/share/thingsboard/bin/thingsboard.jar/!BOOT-INF/classes/!/org/thingsboard/server/service/queue/DefaultTbCalculatedFieldConsumerService.class]: Unsatisfied dependency expressed through constructor parameter 10: Error creating bean with name 'rocksDBCalculatedFieldStateService' defined in URL [jar:nested:/usr/share/thingsboard/bin/thingsboard.jar/!BOOT-INF/classes/!/org/thingsboard/server/service/cf/ctx/state/RocksDBCalculatedFieldStateService.class]: Unsatisfied dependency expressed through constructor parameter 0: Error creating bean with name 'cfRocksDb': Invocation of init method failed
<...>org.springframework.boot.loader.launch.PropertiesLauncher.main(PropertiesLauncher.java:580)
Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'rocksDBCalculatedFieldStateService' defined in URL [jar:nested:/usr/share/thingsboard/bin/thingsboard.jar/!BOOT-INF/classes/!/org/thingsboard/server/service/cf/ctx/state/RocksDBCalculatedFieldStateService.class]: Unsatisfied dependency expressed through constructor parameter 0: Error creating bean with name 'cfRocksDb': Invocation of init method failed
<...>
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'cfRocksDb': Invocation of init method failed
<...>
Caused by: java.nio.file.AccessDeniedException: /nonexistent
<...>
   </pre>  
</details>

This issue currently only affects `tb-postgres`/`tb-pe`, `tb-node`/`tb-pe-node` and `tb-vc-executor`/`tb-pe-vc-executor` images - but I have also added fixes for other images that install `thingsboard.deb` to ensure future features won't be potentially affected by this.

Testing methodology:
1. Branch: https://github.com/trikimiki/tb-docker-base-images/tree/repo-thingsboardsupport
same as current PR one, but with changed target push repo:
```
-        <docker.repo>thingsboard</docker.repo>
+        <docker.repo>thingsboardsupport</docker.repo>
```
2.  Build base and JDK images, push:
https://hub.docker.com/repositories/thingsboardsupport?ordering=last_updated&page=1
```
docker buildx prune -f
mvn clean
mvn clean install -P push-docker-amd-arm-images -pl base -Ddebian.codename=bullseye-slim
mvn clean install -P push-docker-amd-arm-images -pl base
mvn clean install -P push-docker-amd-arm-images -pl '!base'
```
3. Clone CE/PE repos, branch with changed JDK image repo:
e.g. CE https://github.com/trikimiki/thingsboard/tree/test-for-fix-base-image-homedir:
```
-FROM thingsboard/openjdk17:bookworm-slim
+FROM thingsboardsupport/openjdk17:bookworm-slim
```
4. Build CE/PE images:
```
mvn clean
mvn -T 1C clean install -DskipTests -Ddockerfile.skip=false
```
5. Check if home dir is set for user "thingsboard", check if mentioned errors reproduce.
6. I have also tested basic functionality for Docker images with these fixes (login, transport message send).

Tests:
<details>
  <summary>before</summary>
<details>
  <summary>CE</summary>
   <pre>
[mykhailo@mbondar-at-thingsboard-io ~/test/thingsboard/docker]$ docker ps --format "table {{.Image}}" | grep "thingsboard/tb"
thingsboard/tb-snmp-transport:3.9.1
thingsboard/tb-http-transport:3.9.1
thingsboard/tb-vc-executor:3.9.1
thingsboard/tb-mqtt-transport:3.9.1
thingsboard/tb-lwm2m-transport:3.9.1
thingsboard/tb-coap-transport:3.9.1
thingsboard/tb-http-transport:3.9.1
thingsboard/tb-mqtt-transport:3.9.1
thingsboard/tb-vc-executor:3.9.1
thingsboard/tb-node:3.9.1
thingsboard/tb-node:3.9.1
thingsboard/tb-node:3.9.1
thingsboard/tb-node:3.9.1
thingsboard/tb-js-executor:3.9.1
thingsboard/tb-js-executor:3.9.1
thingsboard/tb-js-executor:3.9.1
thingsboard/tb-js-executor:3.9.1
thingsboard/tb-js-executor:3.9.1
thingsboard/tb-js-executor:3.9.1
thingsboard/tb-js-executor:3.9.1
thingsboard/tb-js-executor:3.9.1
thingsboard/tb-js-executor:3.9.1
thingsboard/tb-js-executor:3.9.1
thingsboard/tb-web-ui:3.9.1
thingsboard/tb-web-ui:3.9.1
   </pre>
   <pre>
[mykhailo@mbondar-at-thingsboard-io ~/test/thingsboard/docker]$ for container in $(docker ps -q); do docker exec -it $container sh -c "getent passwd thingsboard"; done
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
   </pre>
</details>
<details>
  <summary>PE</summary>
   <pre>
[mykhailo@mbondar-at-thingsboard-io ~/test-docker-compose/pe/tb-pe-docker-compose]$ docker ps --format "table {{.Image}}" | grep PE
thingsboard/tb-pe-coap-transport:3.9.1PE
thingsboard/tb-pe-mqtt-transport:3.9.1PE
thingsboard/tb-pe-vc-executor:3.9.1PE
thingsboard/tb-pe-snmp-transport:3.9.1PE
thingsboard/tb-pe-lwm2m-transport:3.9.1PE
thingsboard/tb-pe-http-transport:3.9.1PE
thingsboard/tb-pe-node:3.9.1PE
thingsboard/tb-pe-js-executor:3.9.1PE
thingsboard/tb-pe-js-executor:3.9.1PE
thingsboard/tb-pe-js-executor:3.9.1PE
thingsboard/tb-pe-js-executor:3.9.1PE
thingsboard/tb-pe-js-executor:3.9.1PE
thingsboard/tb-pe-js-executor:3.9.1PE
thingsboard/tb-pe-js-executor:3.9.1PE
thingsboard/tb-pe-js-executor:3.9.1PE
thingsboard/tb-pe-js-executor:3.9.1PE
thingsboard/tb-pe-js-executor:3.9.1PE
thingsboard/tb-pe-web-ui:3.9.1PE
thingsboard/tb-pe-web-report:3.9.1PE
   </pre>
   <pre>
[mykhailo@mbondar-at-thingsboard-io ~/test-docker-compose/pe/tb-pe-docker-compose]$ for container in $(docker ps -q); do docker exec -it $container sh -c "getent passwd thingsboard"; done
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
   </pre>
</details>
</details>
<details>
  <summary>after</summary>
<details>
  <summary>CE</summary>
   <pre>
[mykhailo@mbondar-at-thingsboard-io ~/ce-code/thingsboard/docker]$ docker ps --format "table {{.Image}}" | grep "thingsboard/tb"
thingsboard/tb-node:4.0.0-SNAPSHOT
thingsboard/tb-node:4.0.0-SNAPSHOT
thingsboard/tb-node:4.0.0-SNAPSHOT
thingsboard/tb-node:4.0.0-SNAPSHOT
thingsboard/tb-edqs:4.0.0-SNAPSHOT
thingsboard/tb-edqs:4.0.0-SNAPSHOT
thingsboard/tb-mqtt-transport:4.0.0-SNAPSHOT
thingsboard/tb-http-transport:4.0.0-SNAPSHOT
thingsboard/tb-http-transport:4.0.0-SNAPSHOT
thingsboard/tb-mqtt-transport:4.0.0-SNAPSHOT
thingsboard/tb-lwm2m-transport:4.0.0-SNAPSHOT
thingsboard/tb-snmp-transport:4.0.0-SNAPSHOT
thingsboard/tb-vc-executor:4.0.0-SNAPSHOT
thingsboard/tb-vc-executor:4.0.0-SNAPSHOT
thingsboard/tb-coap-transport:4.0.0-SNAPSHOT
thingsboard/tb-js-executor:4.0.0-SNAPSHOT
thingsboard/tb-js-executor:4.0.0-SNAPSHOT
thingsboard/tb-js-executor:4.0.0-SNAPSHOT
thingsboard/tb-js-executor:4.0.0-SNAPSHOT
thingsboard/tb-js-executor:4.0.0-SNAPSHOT
thingsboard/tb-js-executor:4.0.0-SNAPSHOT
thingsboard/tb-js-executor:4.0.0-SNAPSHOT
thingsboard/tb-js-executor:4.0.0-SNAPSHOT
thingsboard/tb-js-executor:4.0.0-SNAPSHOT
thingsboard/tb-js-executor:4.0.0-SNAPSHOT
thingsboard/tb-web-ui:4.0.0-SNAPSHOT
thingsboard/tb-web-ui:4.0.0-SNAPSHOT
   </pre>
   <pre>
[mykhailo@mbondar-at-thingsboard-io ~/ce-code/thingsboard/docker]$ for container in $(docker ps -q); do docker exec -it $container sh -c "getent passwd thingsboard"; done
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
   </pre>
</details>
<details>
  <summary>PE</summary>
   <pre>
[mykhailo@mbondar-at-thingsboard-io ~/test-docker-compose/pe/tb-pe-docker-compose]$ docker ps --format "table {{.Image}}" | grep PE
thingsboard/tb-pe-snmp-transport:4.0.0PE-SNAPSHOT
thingsboard/tb-pe-mqtt-transport:4.0.0PE-SNAPSHOT
thingsboard/tb-pe-lwm2m-transport:4.0.0PE-SNAPSHOT
thingsboard/tb-pe-vc-executor:4.0.0PE-SNAPSHOT
thingsboard/tb-pe-http-transport:4.0.0PE-SNAPSHOT
thingsboard/tb-pe-coap-transport:4.0.0PE-SNAPSHOT
thingsboard/tb-pe-node:4.0.0PE-SNAPSHOT
thingsboard/tb-pe-js-executor:4.0.0PE-SNAPSHOT
thingsboard/tb-pe-js-executor:4.0.0PE-SNAPSHOT
thingsboard/tb-pe-js-executor:4.0.0PE-SNAPSHOT
thingsboard/tb-pe-js-executor:4.0.0PE-SNAPSHOT
thingsboard/tb-pe-js-executor:4.0.0PE-SNAPSHOT
thingsboard/tb-pe-js-executor:4.0.0PE-SNAPSHOT
thingsboard/tb-pe-js-executor:4.0.0PE-SNAPSHOT
thingsboard/tb-pe-js-executor:4.0.0PE-SNAPSHOT
thingsboard/tb-pe-js-executor:4.0.0PE-SNAPSHOT
thingsboard/tb-pe-js-executor:4.0.0PE-SNAPSHOT
thingsboard/tb-pe-web-report:4.0.0PE-SNAPSHOT
thingsboard/tb-pe-web-ui:4.0.0PE-SNAPSHOT
   </pre>
   <pre>
[mykhailo@mbondar-at-thingsboard-io ~/test-docker-compose/pe/tb-pe-docker-compose]$ for container in $(docker ps -q); do docker exec -it $container sh -c "getent passwd thingsboard"; done
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
   </pre>
</details>
</details>

Also, as a part of this PR:
- JDK versions bumped to latest (stable-security for JDK 11,17; latest for JDK 21)
- fixed "website" Dockerfile
  - added `DEBIAN_FRONTEND=noninteractive` - this env should be always enabled when installing via `apt` to automatically handle prompts
  - added `apt-get upgrade` - since base image `ruby:3.2.2` was built a while ago, running `apt-get install` without prior `upgrade` fails
    - this adds around 100MB to the image size; otherwise, the image only builds on the second attempt, when some specific build cache is present - let me know if smaller size is more preferable than "clean" build 
  - double-checked if updated website image properly runs:
  ```
  $ docker run --rm -p 4000:4000 --name thingsboard_website_test_img -e PAGES_REPO_NWO="thingsboard/thingsboard.github.io" --volume="/home/mykhailo/docs-my-clone/thingsboard.github.io:/website" thingsboardsupport/website:1.14.0
  < . . >
  Configuration file: _config.yml
  Configuration file: _config_dev.yml
  To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
              Source: /website
         Destination: /website/_site
   Incremental build: enabled
        Generating... 
     GitHub Metadata: No GitHub API authentication could be found. Some fields may be missing or have incorrect data.
                      done in 208.233 seconds.
   Auto-regeneration: enabled for '/website'
      Server address: http://0.0.0.0:4000
    Server running... press ctrl-c to stop.
  < . . >
  ```