### PR TITLE
Vulnerability fixed: Java 17, Java 21. Updates: kubectl 1.33; Other: legacy ENV syntax refactored

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Build multi-arch images and push to Docker Hub:
 ```bash
 # do not ask user for interactive confirmation
-docker buildx prune -f
+docker buildx prune -af
 mvn clean install -P push-docker-amd-arm-images -pl base -Ddebian.codename=bullseye-slim
 mvn clean install -P push-docker-amd-arm-images -pl base
 mvn clean install -P push-docker-amd-arm-images -pl '!base'

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.14.0</version>
+        <version>1.15.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>base</artifactId>

--- a/haproxy-certbot/pom.xml
+++ b/haproxy-certbot/pom.xml
@@ -21,7 +21,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.14.0</version>
+        <version>1.15.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/kubectl/docker/Dockerfile
+++ b/kubectl/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM bitnami/kubectl:1.31-debian-12
+FROM bitnami/kubectl:1.33-debian-12
 
 USER root
 

--- a/kubectl/pom.xml
+++ b/kubectl/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.14.0</version>
+        <version>1.15.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>kubectl</artifactId>

--- a/medusa/pom.xml
+++ b/medusa/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.14.0</version>
+        <version>1.15.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>medusa</artifactId>

--- a/node/pom.xml
+++ b/node/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.14.0</version>
+        <version>1.15.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>node</artifactId>

--- a/openjdk11/docker/Dockerfile
+++ b/openjdk11/docker/Dockerfile
@@ -18,10 +18,10 @@
 FROM thingsboard/base:${debian.codename}
 
 # Default to UTF-8 file.encoding
-ENV LANG C.UTF-8
-ENV JAVA_HOME /docker-java-home
-ENV JAVA_VERSION 11.0.26
-ENV JAVA_DEBIAN_VERSION 11.0.26+4-1~deb11u1
+ENV LANG=C.UTF-8
+ENV JAVA_HOME=/docker-java-home
+ENV JAVA_VERSION=11.0.26
+ENV JAVA_DEBIAN_VERSION=11.0.26+4-1~deb11u1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \

--- a/openjdk11/pom.xml
+++ b/openjdk11/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.14.0</version>
+        <version>1.15.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk11</artifactId>

--- a/openjdk17/docker/Dockerfile
+++ b/openjdk17/docker/Dockerfile
@@ -17,10 +17,10 @@
 FROM ${docker.repo}/base:${debian.codename}
 
 # Default to UTF-8 file.encoding
-ENV LANG C.UTF-8
-ENV JAVA_HOME /docker-java-home
-ENV JAVA_VERSION 17.0.14
-ENV JAVA_DEBIAN_VERSION 17.0.14+7-1~deb12u1
+ENV LANG=C.UTF-8
+ENV JAVA_HOME=/docker-java-home
+ENV JAVA_VERSION=17.0.14
+ENV JAVA_DEBIAN_VERSION=17.0.14+7-1~deb12u1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \

--- a/openjdk17/docker/Dockerfile
+++ b/openjdk17/docker/Dockerfile
@@ -19,8 +19,8 @@ FROM ${docker.repo}/base:${debian.codename}
 # Default to UTF-8 file.encoding
 ENV LANG=C.UTF-8
 ENV JAVA_HOME=/docker-java-home
-ENV JAVA_VERSION=17.0.14
-ENV JAVA_DEBIAN_VERSION=17.0.14+7-1~deb12u1
+ENV JAVA_VERSION=17.0.15
+ENV JAVA_DEBIAN_VERSION=17.0.15+6-1~deb12u1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \

--- a/openjdk17/pom.xml
+++ b/openjdk17/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.14.0</version>
+        <version>1.15.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk17</artifactId>

--- a/openjdk21/docker/Dockerfile
+++ b/openjdk21/docker/Dockerfile
@@ -19,8 +19,8 @@ FROM ${docker.repo}/base:${debian.codename}
 # Default to UTF-8 file.encoding
 ENV LANG=C.UTF-8
 ENV JAVA_HOME=/docker-java-home
-ENV JAVA_VERSION=21.0.6
-ENV JAVA_DEBIAN_VERSION=21.0.6+7-1
+ENV JAVA_VERSION=21.0.7
+ENV JAVA_DEBIAN_VERSION=21.0.7+6-1
 
 # Remove when stable version is available
 RUN echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.d/trixie.list

--- a/openjdk21/docker/Dockerfile
+++ b/openjdk21/docker/Dockerfile
@@ -17,10 +17,10 @@
 FROM ${docker.repo}/base:${debian.codename}
 
 # Default to UTF-8 file.encoding
-ENV LANG C.UTF-8
-ENV JAVA_HOME /docker-java-home
-ENV JAVA_VERSION 21.0.6
-ENV JAVA_DEBIAN_VERSION 21.0.6+7-1
+ENV LANG=C.UTF-8
+ENV JAVA_HOME=/docker-java-home
+ENV JAVA_VERSION=21.0.6
+ENV JAVA_DEBIAN_VERSION=21.0.6+7-1
 
 # Remove when stable version is available
 RUN echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.d/trixie.list

--- a/openjdk21/pom.xml
+++ b/openjdk21/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.14.0</version>
+        <version>1.15.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk21</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.thingsboard</groupId>
     <artifactId>docker</artifactId>
-    <version>1.14.0</version>
+    <version>1.15.0</version>
     <packaging>pom</packaging>
 
     <name>ThingsBoard Base Docker images</name>

--- a/toolbox/pom.xml
+++ b/toolbox/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.thingsboard</groupId>
         <artifactId>docker</artifactId>
-        <version>1.14.0</version>
+        <version>1.15.0</version>
     </parent>
 
     <artifactId>toolbox</artifactId>

--- a/website/pom.xml
+++ b/website/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.14.0</version>
+        <version>1.15.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>website</artifactId>


### PR DESCRIPTION
Vulnerability fixed: Java 17, Java 21. 
Updates: kubectl 1.33;

legacy ENV syntax refactored to address warnings like this

```
 2 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 21)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 22)
```

tested :
![image](https://github.com/user-attachments/assets/99e04a7c-be32-4391-b418-d44ea1584770)
