### PR TITLE
Feature/mqtt toolbox alpine

### DIFF
--- a/connectivity/mqtt/docker/Dockerfile
+++ b/connectivity/mqtt/docker/Dockerfile
@@ -14,8 +14,38 @@
 # limitations under the License.
 #
 
-FROM efrecon/mqtt-client:2.0.11
+# Reference https://github.com/efrecon/docker-images/blob/master/mqtt-client/Dockerfile
+#ARG ALPINE_VERSION=3.14.1
+FROM alpine:${alpine.version}
 
-USER root
+ARG MOSQUITTO_VERSION=2.0.20
+ARG PACKAGE_RELEASE=0
+ARG BUILD_DATE=2025-05-16
 
-RUN apk --no-cache add curl
+# OCI Meta information
+LABEL org.opencontainers.image.authors="Emmanuel Frecon <efrecon@gmail.com>"
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.version=${MOSQUITTO_VERSION}
+LABEL org.opencontainers.image.url="https://github.com/efrecon/docker-images"
+LABEL org.opencontainers.image.source="https://github.com/efrecon/docker-images/mqtt-client/Dockerfile"
+LABEL org.opencontainers.image.documentation="https://github.com/efrecon/docker-images/mqtt-client/README.md"
+LABEL org.opencontainers.image.licenses="BSD"
+LABEL org.opencontainers.image.title="MQTT Client"
+LABEL org.opencontainers.image.description="mosquitto clients for sending data and/or subscribing to topics"
+
+VOLUME /opt/certs
+
+RUN apk add --no-cache ca-certificates tini mosquitto-clients=${MOSQUITTO_VERSION}-r${PACKAGE_RELEASE} && \
+    /etc/ca-certificates/update.d/certhash && \
+    ln -s /usr/bin/mosquitto_pub /usr/local/bin/pub && \
+    ln -s /usr/bin/mosquitto_sub /usr/local/bin/sub && \
+    apk add --no-cache curl && \
+    mkdir -p /home/nobody && \
+    chown -R nobody:nobody /home/nobody
+
+WORKDIR /home/nobody
+ENV HOME=/home/nobody
+
+USER nobody
+
+ENTRYPOINT [ "/sbin/tini", "--" ]

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <main.dir>${basedir}</main.dir>
         <pkg.user>thingsboard</pkg.user>
         <docker.repo>thingsboard</docker.repo>
-        <alpine.version>3.18</alpine.version>
+        <alpine.version>3.22</alpine.version>
         <debian.codename>bookworm-slim</debian.codename>
         <docker.output.type>registry</docker.output.type>
         <docker.cache>--no-cache</docker.cache>

--- a/toolbox/docker/Dockerfile
+++ b/toolbox/docker/Dockerfile
@@ -19,6 +19,6 @@ RUN apk add --no-cache postgresql-client
 RUN apk add --no-cache py3-pip
 RUN apk add --no-cache bash
 RUN apk add --no-cache curl
-RUN pip install cqlsh
-WORKDIR scripts
+RUN pip install cqlsh --break-system-packages
+WORKDIR /scripts
 COPY *.sh /scripts/


### PR DESCRIPTION
as the base image was amd64 only, 

[mosquito clients dockerfile imported from](https://github.com/thingsboard/docker/commit/9450d7ea147e9b2081d2d2a3716dd1a700028c7c) https://github.com/efrecon/docker-images/blob/master/mqtt-client/Dockerfile

curl and workdir added

test ok

![image](https://github.com/user-attachments/assets/558b258c-4fca-44d3-81cb-42604a24ecb4)

multi arch ok (custom pvt repo)

![image](https://github.com/user-attachments/assets/7a2f733b-e774-42f4-8e65-5d6adc0dfc79)


[toolbox compatibility fix with alpine:3.22](https://github.com/thingsboard/docker/commit/240c04df761f65250c9c23c341192348cffc67d4)

![image](https://github.com/user-attachments/assets/d8997204-7e00-48a4-8976-bad5ccaae45a)
