### PR TITLE
Security updates

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.16.0</version>
+        <version>1.17.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>base</artifactId>

--- a/connectivity/coap/pom.xml
+++ b/connectivity/coap/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.thingsboard</groupId>
 		<artifactId>connectivity</artifactId>
-		<version>1.16.0</version>
+		<version>1.17.0</version>
 	</parent>
 
 	<groupId>org.thingsboard.connectivity</groupId>

--- a/connectivity/mqtt/docker/Dockerfile
+++ b/connectivity/mqtt/docker/Dockerfile
@@ -18,9 +18,9 @@
 #ARG ALPINE_VERSION=3.14.1
 FROM alpine:${alpine.version}
 
-ARG MOSQUITTO_VERSION=2.0.20
+ARG MOSQUITTO_VERSION=2.0.21
 ARG PACKAGE_RELEASE=0
-ARG BUILD_DATE=2025-05-16
+ARG BUILD_DATE=2025-08-14
 
 # OCI Meta information
 LABEL org.opencontainers.image.authors="Emmanuel Frecon <efrecon@gmail.com>"

--- a/connectivity/mqtt/pom.xml
+++ b/connectivity/mqtt/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.thingsboard</groupId>
 		<artifactId>connectivity</artifactId>
-		<version>1.16.0</version>
+		<version>1.17.0</version>
 	</parent>
 	
 	<groupId>org.thingsboard.connectivity</groupId>

--- a/connectivity/pom.xml
+++ b/connectivity/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.thingsboard</groupId>
 		<artifactId>docker</artifactId>
-		<version>1.16.0</version>
+		<version>1.17.0</version>
 	</parent>
 
 	<artifactId>connectivity</artifactId>

--- a/haproxy-certbot/pom.xml
+++ b/haproxy-certbot/pom.xml
@@ -21,7 +21,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.16.0</version>
+        <version>1.17.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/kubectl/docker/Dockerfile
+++ b/kubectl/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM bitnami/kubectl:1.33-debian-12
+FROM bitnamilegacy/kubectl:1.33-debian-12
 
 USER root
 

--- a/kubectl/pom.xml
+++ b/kubectl/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.16.0</version>
+        <version>1.17.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>kubectl</artifactId>

--- a/medusa/pom.xml
+++ b/medusa/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.16.0</version>
+        <version>1.17.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>medusa</artifactId>

--- a/node/pom.xml
+++ b/node/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.16.0</version>
+        <version>1.17.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>node</artifactId>

--- a/openjdk11/docker/Dockerfile
+++ b/openjdk11/docker/Dockerfile
@@ -20,8 +20,8 @@ FROM thingsboard/base:${debian.codename}
 # Default to UTF-8 file.encoding
 ENV LANG=C.UTF-8
 ENV JAVA_HOME=/docker-java-home
-ENV JAVA_VERSION=11.0.27
-ENV JAVA_DEBIAN_VERSION=11.0.27+6-1~deb11u1
+ENV JAVA_VERSION=11.0.28
+ENV JAVA_DEBIAN_VERSION=11.0.28+6-1~deb11u1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \

--- a/openjdk11/pom.xml
+++ b/openjdk11/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.16.0</version>
+        <version>1.17.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk11</artifactId>

--- a/openjdk17/docker/Dockerfile
+++ b/openjdk17/docker/Dockerfile
@@ -19,8 +19,8 @@ FROM ${docker.repo}/base:${debian.codename}
 # Default to UTF-8 file.encoding
 ENV LANG=C.UTF-8
 ENV JAVA_HOME=/docker-java-home
-ENV JAVA_VERSION=17.0.15
-ENV JAVA_DEBIAN_VERSION=17.0.15+6-1~deb12u1
+ENV JAVA_VERSION=17.0.16
+ENV JAVA_DEBIAN_VERSION=17.0.16+8-1~deb12u1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \

--- a/openjdk17/pom.xml
+++ b/openjdk17/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.16.0</version>
+        <version>1.17.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk17</artifactId>

--- a/openjdk21/docker/Dockerfile
+++ b/openjdk21/docker/Dockerfile
@@ -19,8 +19,8 @@ FROM ${docker.repo}/base:${debian.codename}
 # Default to UTF-8 file.encoding
 ENV LANG=C.UTF-8
 ENV JAVA_HOME=/docker-java-home
-ENV JAVA_VERSION=21.0.7
-ENV JAVA_DEBIAN_VERSION=21.0.7+6-1
+ENV JAVA_VERSION=21.0.8
+ENV JAVA_DEBIAN_VERSION=21.0.8+9-1
 
 # Remove when stable version is available
 RUN echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.d/trixie.list

--- a/openjdk21/pom.xml
+++ b/openjdk21/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.16.0</version>
+        <version>1.17.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk21</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <docker.pull>--pull</docker.pull>
         <dockerfile.skip>true</dockerfile.skip>
         <haproxy.version>2.2.33</haproxy.version>
-        <node.version>20.18.0</node.version>
+        <node.version>20.19.4</node.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <docker.push-arm-amd-image.phase>none</docker.push-arm-amd-image.phase>
         <docker.push-arm-amd-image-latest.phase>none</docker.push-arm-amd-image-latest.phase>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.thingsboard</groupId>
     <artifactId>docker</artifactId>
-    <version>1.16.0</version>
+    <version>1.17.0</version>
     <packaging>pom</packaging>
 
     <name>ThingsBoard Base Docker images</name>

--- a/toolbox/pom.xml
+++ b/toolbox/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.thingsboard</groupId>
         <artifactId>docker</artifactId>
-        <version>1.16.0</version>
+        <version>1.17.0</version>
     </parent>
 
     <artifactId>toolbox</artifactId>

--- a/website/pom.xml
+++ b/website/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.16.0</version>
+        <version>1.17.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>website</artifactId>


### PR DESCRIPTION
## Security updates

- Java security version bump 11,17,21
- node.version 20.19.4 from 20.18.0 (consulted with @vvlladd28)
- kubectl from bitnamilegacy repo
- mosquito mqtt client update from 2.0.20 to 2.0.21

## Checks
```
docker scout quickview sevlamat/node:20.19.4-bookworm-slim
docker scout quickview sevlamat/openjdk17:bookworm-slim
```

<img width="1188" height="140" alt="image" src="https://github.com/user-attachments/assets/4ff82a52-279b-4e47-bc96-d3464d252e0d" />

<img width="1248" height="182" alt="image" src="https://github.com/user-attachments/assets/1b6178e2-e795-435e-9d5b-a076366b4f16" />

## mqtt client test:

```bash
docker run --rm -it sevlamat/mosquitto-clients mosquitto_pub --version
mosquitto_pub version 2.0.21 running on libmosquitto 2.0.21.
```

<img width="1294" height="184" alt="image" src="https://github.com/user-attachments/assets/631faa3b-cda5-42be-bd5b-8d70411758bd" />
<img width="1662" height="910" alt="image" src="https://github.com/user-attachments/assets/a2e023e0-7b99-4e9c-bd82-0d8b50519803" />

<img width="2776" height="740" alt="image" src="https://github.com/user-attachments/assets/f61eecc8-a133-4ca8-adbe-94b7ec19ee71" />



 