### PR TITLE
nodejs upgrade 20.19.4 -> 22.18.0

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.17.0</version>
+        <version>1.18.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>base</artifactId>

--- a/connectivity/coap/pom.xml
+++ b/connectivity/coap/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.thingsboard</groupId>
 		<artifactId>connectivity</artifactId>
-		<version>1.17.0</version>
+		<version>1.18.0</version>
 	</parent>
 
 	<groupId>org.thingsboard.connectivity</groupId>

--- a/connectivity/mqtt/pom.xml
+++ b/connectivity/mqtt/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.thingsboard</groupId>
 		<artifactId>connectivity</artifactId>
-		<version>1.17.0</version>
+		<version>1.18.0</version>
 	</parent>
 	
 	<groupId>org.thingsboard.connectivity</groupId>

--- a/connectivity/pom.xml
+++ b/connectivity/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.thingsboard</groupId>
 		<artifactId>docker</artifactId>
-		<version>1.17.0</version>
+		<version>1.18.0</version>
 	</parent>
 
 	<artifactId>connectivity</artifactId>

--- a/haproxy-certbot/pom.xml
+++ b/haproxy-certbot/pom.xml
@@ -21,7 +21,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.17.0</version>
+        <version>1.18.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/kubectl/pom.xml
+++ b/kubectl/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.17.0</version>
+        <version>1.18.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>kubectl</artifactId>

--- a/medusa/pom.xml
+++ b/medusa/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.17.0</version>
+        <version>1.18.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>medusa</artifactId>

--- a/node/pom.xml
+++ b/node/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.17.0</version>
+        <version>1.18.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>node</artifactId>

--- a/openjdk11/pom.xml
+++ b/openjdk11/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.17.0</version>
+        <version>1.18.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk11</artifactId>

--- a/openjdk17/pom.xml
+++ b/openjdk17/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.17.0</version>
+        <version>1.18.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk17</artifactId>

--- a/openjdk21/pom.xml
+++ b/openjdk21/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.17.0</version>
+        <version>1.18.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk21</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.thingsboard</groupId>
     <artifactId>docker</artifactId>
-    <version>1.17.0</version>
+    <version>1.18.0</version>
     <packaging>pom</packaging>
 
     <name>ThingsBoard Base Docker images</name>
@@ -38,7 +38,7 @@
         <docker.pull>--pull</docker.pull>
         <dockerfile.skip>true</dockerfile.skip>
         <haproxy.version>2.2.33</haproxy.version>
-        <node.version>20.19.4</node.version>
+        <node.version>22.18.0</node.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <docker.push-arm-amd-image.phase>none</docker.push-arm-amd-image.phase>
         <docker.push-arm-amd-image-latest.phase>none</docker.push-arm-amd-image-latest.phase>

--- a/toolbox/pom.xml
+++ b/toolbox/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.thingsboard</groupId>
         <artifactId>docker</artifactId>
-        <version>1.17.0</version>
+        <version>1.18.0</version>
     </parent>
 
     <artifactId>toolbox</artifactId>

--- a/website/pom.xml
+++ b/website/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.17.0</version>
+        <version>1.18.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>website</artifactId>


### PR DESCRIPTION
nodejs upgrade 20.19.4 -> 22.18.0

related to nodejs upgrade https://github.com/thingsboard/thingsboard/pull/13886

<img width="1378" height="880" alt="image" src="https://github.com/user-attachments/assets/5887995c-1c20-464a-a24b-ca7ef6568702" />

