### PR TITLE
Open JDK 25 base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Build multi-arch images and push to Docker Hub:
 # do not ask user for interactive confirmation
 docker buildx prune -af
 mvn clean install -P push-docker-amd-arm-images -pl base -Ddebian.codename=bullseye-slim
+mvn clean install -P push-docker-amd-arm-images -pl base -Ddebian.codename=trixie-slim
 mvn clean install -P push-docker-amd-arm-images -pl base
 mvn clean install -P push-docker-amd-arm-images -pl '!base'
 ```

--- a/base/docker/Dockerfile
+++ b/base/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/base/docker/Dockerfile
+++ b/base/docker/Dockerfile
@@ -19,7 +19,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
     && apt-get upgrade --yes \
-    && apt-get install -y --no-install-recommends procps \
+    && apt-get install -y --no-install-recommends procps adduser \
     && apt-get autoremove --purge --yes \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright © 2016-2024 The Thingsboard Authors
+    Copyright © 2016-2025 The Thingsboard Authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.20.0</version>
+        <version>1.21.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>base</artifactId>

--- a/build_and_push_all.sh
+++ b/build_and_push_all.sh
@@ -31,7 +31,8 @@ set -x
 docker buildx prune -af
 mvn clean install -P push-docker-amd-arm-images -pl base -Ddebian.codename=bullseye-slim
 mvn clean install -P push-docker-amd-arm-images -pl base -Ddebian.codename=trixie-slim
-mvn clean install -P push-docker-amd-arm-images -pl base # uses default Debian codename (from pom.xml's)
+# Base image build below will use default Debian codename (from pom.xml's)
+mvn clean install -P push-docker-amd-arm-images -pl base
 mvn clean install -P push-docker-amd-arm-images -pl '!base'
 
 set +x

--- a/build_and_push_all.sh
+++ b/build_and_push_all.sh
@@ -30,7 +30,8 @@ set -x
 # Performing the same steps as described in README.md
 docker buildx prune -af
 mvn clean install -P push-docker-amd-arm-images -pl base -Ddebian.codename=bullseye-slim
-mvn clean install -P push-docker-amd-arm-images -pl base
+mvn clean install -P push-docker-amd-arm-images -pl base -Ddebian.codename=trixie-slim
+mvn clean install -P push-docker-amd-arm-images -pl base # uses default Debian codename (from pom.xml's)
 mvn clean install -P push-docker-amd-arm-images -pl '!base'
 
 set +x

--- a/build_and_push_all.sh
+++ b/build_and_push_all.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/connectivity/coap/docker/Dockerfile
+++ b/connectivity/coap/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/connectivity/coap/pom.xml
+++ b/connectivity/coap/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2016-2024 The Thingsboard Authors
+    Copyright © 2016-2025 The Thingsboard Authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/connectivity/coap/pom.xml
+++ b/connectivity/coap/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.thingsboard</groupId>
 		<artifactId>connectivity</artifactId>
-		<version>1.20.0</version>
+		<version>1.21.0</version>
 	</parent>
 
 	<groupId>org.thingsboard.connectivity</groupId>

--- a/connectivity/mqtt/docker/Dockerfile
+++ b/connectivity/mqtt/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/connectivity/mqtt/pom.xml
+++ b/connectivity/mqtt/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2016-2024 The Thingsboard Authors
+    Copyright © 2016-2025 The Thingsboard Authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/connectivity/mqtt/pom.xml
+++ b/connectivity/mqtt/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.thingsboard</groupId>
 		<artifactId>connectivity</artifactId>
-		<version>1.20.0</version>
+		<version>1.21.0</version>
 	</parent>
 	
 	<groupId>org.thingsboard.connectivity</groupId>

--- a/connectivity/pom.xml
+++ b/connectivity/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2016-2024 The Thingsboard Authors
+    Copyright © 2016-2025 The Thingsboard Authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/connectivity/pom.xml
+++ b/connectivity/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.thingsboard</groupId>
 		<artifactId>docker</artifactId>
-		<version>1.20.0</version>
+		<version>1.21.0</version>
 	</parent>
 
 	<artifactId>connectivity</artifactId>

--- a/haproxy-certbot/docker/Dockerfile
+++ b/haproxy-certbot/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/haproxy-certbot/docker/certbot-certonly.sh
+++ b/haproxy-certbot/docker/certbot-certonly.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/haproxy-certbot/docker/certbot-renew.sh
+++ b/haproxy-certbot/docker/certbot-renew.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/haproxy-certbot/docker/haproxy-check.sh
+++ b/haproxy-certbot/docker/haproxy-check.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/haproxy-certbot/docker/haproxy-refresh.sh
+++ b/haproxy-certbot/docker/haproxy-refresh.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/haproxy-certbot/docker/haproxy-restart.sh
+++ b/haproxy-certbot/docker/haproxy-restart.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/haproxy-certbot/docker/start.sh
+++ b/haproxy-certbot/docker/start.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/haproxy-certbot/pom.xml
+++ b/haproxy-certbot/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2016-2024 The Thingsboard Authors
+    Copyright © 2016-2025 The Thingsboard Authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/haproxy-certbot/pom.xml
+++ b/haproxy-certbot/pom.xml
@@ -21,7 +21,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.20.0</version>
+        <version>1.21.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/kubectl/docker/Dockerfile
+++ b/kubectl/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/kubectl/pom.xml
+++ b/kubectl/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright © 2016-2024 The Thingsboard Authors
+    Copyright © 2016-2025 The Thingsboard Authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/kubectl/pom.xml
+++ b/kubectl/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.20.0</version>
+        <version>1.21.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>kubectl</artifactId>

--- a/license-header-template.txt
+++ b/license-header-template.txt
@@ -1,4 +1,4 @@
-Copyright © ${project.inceptionYear}-2024 ${owner}
+Copyright © ${project.inceptionYear}-2025 ${owner}
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/medusa/docker/Dockerfile
+++ b/medusa/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/medusa/pom.xml
+++ b/medusa/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright © 2016-2024 The Thingsboard Authors
+    Copyright © 2016-2025 The Thingsboard Authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/medusa/pom.xml
+++ b/medusa/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.20.0</version>
+        <version>1.21.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>medusa</artifactId>

--- a/node/docker/Dockerfile
+++ b/node/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/node/pom.xml
+++ b/node/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright © 2016-2024 The Thingsboard Authors
+    Copyright © 2016-2025 The Thingsboard Authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/node/pom.xml
+++ b/node/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.20.0</version>
+        <version>1.21.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>node</artifactId>

--- a/openjdk11/docker/Dockerfile
+++ b/openjdk11/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/openjdk11/docker/Dockerfile
+++ b/openjdk11/docker/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && ln -svT "/usr/lib/jvm/java-11-openjdk-$(dpkg --print-architecture)" /docker-java-home \
     && mkdir -p /usr/share/man/man1 \
     && set -ex \
-    && apt list openjdk-11-jdk-headless -a | grep openjdk-11-jdk-headless \
+    && apt-cache madison openjdk-11-jdk-headless \
     && apt-get install -y --no-install-recommends \
     openjdk-11-jdk-headless="$JAVA_DEBIAN_VERSION" \
     && apt-get autoremove --purge --yes \

--- a/openjdk11/pom.xml
+++ b/openjdk11/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright © 2016-2024 The Thingsboard Authors
+    Copyright © 2016-2025 The Thingsboard Authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/openjdk11/pom.xml
+++ b/openjdk11/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.20.0</version>
+        <version>1.21.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk11</artifactId>

--- a/openjdk17/docker/Dockerfile
+++ b/openjdk17/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/openjdk17/docker/Dockerfile
+++ b/openjdk17/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && ln -svT "/usr/lib/jvm/java-17-openjdk-$(dpkg --print-architecture)" /docker-java-home \
     && mkdir -p /usr/share/man/man1 \
     && set -ex \
-    && apt list openjdk-17-jdk-headless -a | grep openjdk-17-jdk-headless \
+    && apt-cache madison openjdk-17-jdk-headless \
     && apt-get install -y --no-install-recommends \
     openjdk-17-jdk-headless="$JAVA_DEBIAN_VERSION" \
     && apt-get autoremove --purge --yes \

--- a/openjdk17/pom.xml
+++ b/openjdk17/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright © 2016-2024 The Thingsboard Authors
+    Copyright © 2016-2025 The Thingsboard Authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/openjdk17/pom.xml
+++ b/openjdk17/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.20.0</version>
+        <version>1.21.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk17</artifactId>

--- a/openjdk21/docker/Dockerfile
+++ b/openjdk21/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/openjdk21/docker/Dockerfile
+++ b/openjdk21/docker/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && ln -svT "/usr/lib/jvm/java-21-openjdk-$(dpkg --print-architecture)" /docker-java-home \
     && mkdir -p /usr/share/man/man1 \
     && set -ex \
-    && apt list openjdk-21-jdk-headless -a | grep openjdk-21-jdk-headless \
+    && apt-cache madison openjdk-21-jdk-headless \
     && apt-get install -y --no-install-recommends \
     openjdk-21-jdk-headless="$JAVA_DEBIAN_VERSION" \
     && apt-get autoremove --purge --yes \

--- a/openjdk21/docker/Dockerfile
+++ b/openjdk21/docker/Dockerfile
@@ -19,11 +19,8 @@ FROM ${docker.repo}/base:${debian.codename}
 # Default to UTF-8 file.encoding
 ENV LANG=C.UTF-8
 ENV JAVA_HOME=/docker-java-home
-ENV JAVA_VERSION=21.0.8
-ENV JAVA_DEBIAN_VERSION=21.0.8+9-1
-
-# Remove when stable version is available
-RUN echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.d/trixie.list
+ENV JAVA_VERSION=21.0.9
+ENV JAVA_DEBIAN_VERSION=21.0.9+10-1~deb13u1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \

--- a/openjdk21/pom.xml
+++ b/openjdk21/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright © 2016-2024 The Thingsboard Authors
+    Copyright © 2016-2025 The Thingsboard Authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/openjdk21/pom.xml
+++ b/openjdk21/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.20.0</version>
+        <version>1.21.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk21</artifactId>

--- a/openjdk21/pom.xml
+++ b/openjdk21/pom.xml
@@ -33,6 +33,10 @@
     <properties>
         <main.dir>${basedir}/..</main.dir>
         <docker.name>openjdk21</docker.name>
+
+        <!-- override value from parent to ensure that 'trixie-slim' (stable) is used by default because 'bookworm-slim' (oldstable) does not support JDK 21 -->
+        <debian.codename>trixie-slim</debian.codename>
+
         <docker.push-arm-amd-image.phase>pre-integration-test</docker.push-arm-amd-image.phase>
         <docker.push-arm-amd-image-debian-codename.phase>pre-integration-test</docker.push-arm-amd-image-debian-codename.phase>
     </properties>

--- a/openjdk25/docker/Dockerfile
+++ b/openjdk25/docker/Dockerfile
@@ -1,0 +1,55 @@
+#
+# Copyright © 2016-2025 The Thingsboard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM ${docker.repo}/base:${debian.codename}
+
+# Default to UTF-8 file.encoding
+ENV LANG=C.UTF-8
+ENV JAVA_HOME=/docker-java-home
+ENV JAVA_VERSION=25.0.1
+ENV JAVA_DEBIAN_VERSION=25.0.1+8-1~deb13u1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    ca-certificates \
+    && { \
+    echo '#!/bin/sh'; \
+    echo 'set -e'; \
+    echo; \
+    echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
+    } > /usr/local/bin/docker-java-home \
+    && chmod +x /usr/local/bin/docker-java-home \
+    && ln -svT "/usr/lib/jvm/java-25-openjdk-$(dpkg --print-architecture)" /docker-java-home \
+    && mkdir -p /usr/share/man/man1 \
+    && set -ex \
+    && apt-cache madison openjdk-25-jdk-headless \
+    && apt-get install -y --no-install-recommends \
+    openjdk-25-jdk-headless="$JAVA_DEBIAN_VERSION" \
+    && apt-get autoremove --purge --yes \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+# expire resolved DNS in 60 sec
+    && echo 'networkaddress.cache.ttl=60' >> /etc/java-25-openjdk/security/java.security \
+    && tail /etc/java-25-openjdk/security/java.security \
+# verify that "docker-java-home" returns what we expect
+    && [ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ] \
+    && pwd \
+    && ls -lah ~ \
+# basic smoke test
+    && fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ] \
+    && rm -rf ~/.java \
+	&& javac -version \
+	&& java -version

--- a/openjdk25/pom.xml
+++ b/openjdk25/pom.xml
@@ -1,0 +1,168 @@
+<!--
+
+    Copyright © 2016-2025 The Thingsboard Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.thingsboard</groupId>
+        <version>1.20.0</version>
+        <artifactId>docker</artifactId>
+    </parent>
+    <artifactId>openjdk25</artifactId>
+    <packaging>pom</packaging>
+
+    <name>ThingsBoard Open JDK 25 Image</name>
+    <url>https://thingsboard.io</url>
+    <description>ThingsBoard Open JDK 25 Image</description>
+
+    <properties>
+        <main.dir>${basedir}/..</main.dir>
+        <docker.name>openjdk25</docker.name>
+
+        <!-- override value from parent to ensure that 'trixie-slim' (stable) is used by default because 'bookworm-slim' (oldstable) does not support JDK 25 -->
+        <debian.codename>trixie-slim</debian.codename>
+
+        <docker.push-arm-amd-image.phase>pre-integration-test</docker.push-arm-amd-image.phase>
+        <docker.push-arm-amd-image-debian-codename.phase>pre-integration-test</docker.push-arm-amd-image-debian-codename.phase>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-docker-config</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>docker</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build-docker-image</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${dockerfile.skip}</skip>
+                            <repository>${docker.repo}/${docker.name}</repository>
+                            <verbose>true</verbose>
+                            <googleContainerRegistryEnabled>false</googleContainerRegistryEnabled>
+                            <contextDirectory>${project.build.directory}</contextDirectory>
+                            <!-- This prevents checking the latest version on docker hub to address a manifest not found issue -->
+                            <pullNewerImage>false</pullNewerImage>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tag-docker-image</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>tag</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${dockerfile.skip}</skip>
+                            <repository>${docker.repo}/${docker.name}</repository>
+                            <tag>${project.version}</tag>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tag-debian-codename-docker-image</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>tag</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${dockerfile.skip}</skip>
+                            <repository>${docker.repo}/${docker.name}</repository>
+                            <tag>${debian.codename}</tag>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>push-docker-image</id>
+            <activation>
+                <property>
+                    <name>push-docker-image</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.spotify</groupId>
+                        <artifactId>dockerfile-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>push-latest-docker-image</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>push</goal>
+                                </goals>
+                                <configuration>
+                                    <tag>latest</tag>
+                                    <repository>${docker.repo}/${docker.name}</repository>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>push-version-docker-image</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>push</goal>
+                                </goals>
+                                <configuration>
+                                    <tag>${project.version}</tag>
+                                    <repository>${docker.repo}/${docker.name}</repository>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+    <repositories>
+        <repository>
+            <id>jenkins</id>
+            <name>Jenkins Repository</name>
+            <url>http://repo.jenkins-ci.org/releases</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+</project>

--- a/openjdk25/pom.xml
+++ b/openjdk25/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.20.0</version>
+        <version>1.21.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>openjdk25</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright © 2016-2024 The Thingsboard Authors
+    Copyright © 2016-2025 The Thingsboard Authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.thingsboard</groupId>
     <artifactId>docker</artifactId>
-    <version>1.20.0</version>
+    <version>1.21.0</version>
     <packaging>pom</packaging>
 
     <name>ThingsBoard Base Docker images</name>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <module>openjdk11</module>
         <module>openjdk17</module>
         <module>openjdk21</module>
+        <module>openjdk25</module>
         <module>haproxy-certbot</module>
         <module>website</module>
         <module>toolbox</module>

--- a/toolbox/docker/Dockerfile
+++ b/toolbox/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/toolbox/docker/cqlsh-validator.sh
+++ b/toolbox/docker/cqlsh-validator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/toolbox/docker/psql-validator.sh
+++ b/toolbox/docker/psql-validator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/toolbox/docker/script-runner.sh
+++ b/toolbox/docker/script-runner.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/toolbox/pom.xml
+++ b/toolbox/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright © 2016-2024 The Thingsboard Authors
+    Copyright © 2016-2025 The Thingsboard Authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/toolbox/pom.xml
+++ b/toolbox/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.thingsboard</groupId>
         <artifactId>docker</artifactId>
-        <version>1.20.0</version>
+        <version>1.21.0</version>
     </parent>
 
     <artifactId>toolbox</artifactId>

--- a/website/docker/Dockerfile
+++ b/website/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright © 2016-2024 The Thingsboard Authors
+# Copyright © 2016-2025 The Thingsboard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/website/pom.xml
+++ b/website/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright © 2016-2024 The Thingsboard Authors
+    Copyright © 2016-2025 The Thingsboard Authors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/website/pom.xml
+++ b/website/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.thingsboard</groupId>
-        <version>1.20.0</version>
+        <version>1.21.0</version>
         <artifactId>docker</artifactId>
     </parent>
     <artifactId>website</artifactId>


### PR DESCRIPTION
**JDK 25 Image**

Added new OpenJDK 25 base image built on Debian Trixie (13). Since JDK 25 is only available in Trixie repositories, the `openjdk25` module overrides `debian.codename` to `trixie-slim` in its `pom.xml`. The build script was updated to build `base:trixie-slim` before building `base` with defaults from `pom.xml`.

**JDK 21 Image Fix**

Fixed the `openjdk21` image which was incorrectly reporting as Trixie despite being tagged `bookworm-slim` (see screenshot below). The previous implementation added the Trixie repository to Bookworm to access JDK 21, but `apt` upgraded core packages including `base-files`, effectively converting the image to Trixie. Since Trixie is now stable and includes JDK 21 natively, the workaround was removed and openjdk21 now uses `base:trixie-slim` directly.

Changes:
- Add Open JDK 25 base image:
  - Install `adduser` for the `base` image explicitly because `trixie-slim` does not include it
  - Update build script to build `base` image for `trixie-slim`
  - Add new `openjdk25` module
  - Add `Dockerfile` file itself for Open JDK 25 (same as for other JDK base images with only change being JDK 25 version)
  - Bump project version to `1.21.0`
- Open JDK 21 base image fix:
  - Use `trixie-slim` directly instead of using `bookworm-slim` with a "hack" with adding `trixie` repo to get JDK 21.
  - Bump JDK 21 minor version from `21.0.8` to `21.0.9`
- Other minor improvements:
  - Update year in license header
  - Fix warnings caused by using `apt list` for printing debug info by using `apt-cache madison` instead
  
Screenshot with OpenJDK 21 issue:
<img width="992" height="393" alt="image" src="https://github.com/user-attachments/assets/2354b7e2-6c6b-4347-aecb-9ab0aa9fab4e" />
  