### PR TITLE
toolbox: fix arm64 build by adding deps for cassandra-driver

### DIFF
--- a/toolbox/docker/Dockerfile
+++ b/toolbox/docker/Dockerfile
@@ -23,7 +23,10 @@ RUN apk add --no-cache curl
 RUN apk add --no-cache ca-certificates
 RUN apk add --no-cache jq
 # --break-system-packages
-RUN pip install cqlsh
+RUN apk add --no-cache --virtual .build-deps \
+        gcc musl-dev python3-dev libffi-dev openssl-dev libev-dev make \
+ && pip install cqlsh \
+ && apk del .build-deps
 RUN curl -fsSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${TARGETARCH}" \
     -o /usr/local/bin/yq \
     && chmod +x /usr/local/bin/yq


### PR DESCRIPTION
## Summary
- `pip install cqlsh` pulls `cassandra-driver`, which has no musl wheel for `linux/arm64`, so pip compiles its C extensions from source. Alpine ships without `gcc` or `libev` headers, so the build fails on `cmurmur3` (no compiler) and then on `libevwrapper` (`fatal error: ev.h: No such file or directory`).
- Install `gcc`, `musl-dev`, `python3-dev`, `libffi-dev`, `openssl-dev`, `libev-dev`, and `make` as a virtual `.build-deps` package before `pip install`, then `apk del .build-deps` so the runtime image stays the same size.

## Test plan
- [x] `mvn clean install -P push-docker-amd-arm-images -pl toolbox` succeeds for `linux/amd64`, `linux/arm64`, and `linux/arm/v7`
- [x] `cqlsh --version`, `psql --version`, `jq --version`, `yq --version` all succeed in the resulting image